### PR TITLE
add support for github token exchange api to authenticate with the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # Nullify CLI
 
 This project is for a CLI tool to interact with Nullify.
+
+## Usage
+
+```
+Usage: nullify [--host HOST] [--verbose] [--debug] [--nullify-token NULLIFY-TOKEN] [--github-token GITHUB-TOKEN] <command> [<args>]
+
+Options:
+  --host HOST, -h HOST [default: https://api.nullify.ai]
+  --verbose, -v          enable verbose logging
+  --debug, -d            enable debug logging
+  --nullify-token NULLIFY-TOKEN
+                         nullify api token
+  --github-token GITHUB-TOKEN
+                         github actions job token to exchange for a nullify token
+  --help, -h             display this help and exit
+
+Commands:
+  dast                   test the given API for bugs and vulnerabilities
+```

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -25,7 +25,7 @@ type DAST struct {
 }
 
 var args struct {
-	DAST    *DAST  `arg:"subcommand:test" help:"test the given API for bugs and vulnerabilities"`
+	DAST    *DAST  `arg:"subcommand:dast" help:"test the given API for bugs and vulnerabilities"`
 	Host    string `arg:"-h,--host" default:"https://api.nullify.ai"`
 	Verbose bool   `arg:"-v" help:"enable verbose logging"`
 	Debug   bool   `arg:"-d" help:"enable debug logging"`

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -29,6 +29,8 @@ var args struct {
 	Host    string `arg:"-h,--host" default:"https://api.nullify.ai"`
 	Verbose bool   `arg:"-v" help:"enable verbose logging"`
 	Debug   bool   `arg:"-d" help:"enable debug logging"`
+
+	models.AuthSources
 }
 
 func main() {
@@ -96,7 +98,11 @@ func main() {
 			authHeaders[headerName] = headerValue
 		}
 
-		httpClient := client.NewHTTPClient()
+		httpClient, err := client.NewHTTPClient(args.Host, &args.AuthSources)
+		if err != nil {
+			logger.Error("failed to create http client", logger.Err(err))
+			os.Exit(1)
+		}
 
 		out, err := dast.StartScan(httpClient, args.Host, &dast.StartScanInput{
 			AppName:     args.DAST.AppName,

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -54,6 +54,10 @@ func getToken(nullifyHost string, authSources *models.AuthSources) (string, erro
 
 		parts := strings.Split(repo, "/")
 
+		if len(parts) != 2 {
+			return "", fmt.Errorf("invalid repository: %s", repo)
+		}
+
 		owner := parts[0]
 
 		url := fmt.Sprintf("https://%s/auth/github_token?token=%s&owner=%s", nullifyHost, authSources.GitHubToken, owner)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,23 +1,76 @@
 package client
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"os"
+	"strings"
+
+	"github.com/nullify-platform/cli/internal/models"
 )
 
 type authTransport struct {
+	token     string
 	transport http.RoundTripper
 }
 
 func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+os.Getenv("NULLIFY_TOKEN"))
+	req.Header.Set("Authorization", "Bearer "+t.token)
 	return t.transport.RoundTrip(req)
 }
 
-func NewHTTPClient() *http.Client {
+func NewHTTPClient(nullifyHost string, authSources *models.AuthSources) (*http.Client, error) {
+	token, error := getToken(nullifyHost, authSources)
+	if error != nil {
+		return nil, error
+	}
+
 	return &http.Client{
 		Transport: &authTransport{
+			token:     token,
 			transport: http.DefaultTransport,
 		},
+	}, nil
+}
+
+var ErrNoToken = errors.New("no token detected")
+
+func getToken(nullifyHost string, authSources *models.AuthSources) (string, error) {
+	if authSources.NullifyToken != "" {
+		return authSources.NullifyToken, nil
 	}
+
+	token := os.Getenv("NULLIFY_TOKEN")
+	if token != "" {
+		return token, nil
+	}
+
+	if os.Getenv("GITHUB_ACTIONS") == "true" &&
+		authSources.GitHubToken != "" &&
+		os.Getenv("GITHUB_ACTION_REPOSITORY") != "" {
+		repo := os.Getenv("GITHUB_ACTION_REPOSITORY")
+
+		parts := strings.Split(repo, "/")
+
+		owner := parts[0]
+
+		url := fmt.Sprintf("https://%s/auth/github_token?token=%s&owner=%s", nullifyHost, authSources.GitHubToken, owner)
+
+		res, err := http.Get(url)
+		if err != nil {
+			return "", err
+		}
+
+		var token githubToken
+		err = json.NewDecoder(res.Body).Decode(&token)
+		if err != nil {
+			return "", err
+		}
+
+		return token.Token, nil
+	}
+
+	return "", ErrNoToken
 }

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -1,0 +1,5 @@
+package client
+
+type githubToken struct {
+	Token string `json:"accessToken"`
+}

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -1,0 +1,6 @@
+package models
+
+type AuthSources struct {
+	NullifyToken string `arg:"--nullify-token" help:"nullify api token"`
+	GitHubToken  string `arg:"--github-token" help:"github actions job token to exchange for a nullify token"`
+}


### PR DESCRIPTION
## Description

Add a --github-token argument to give the CLI a github actions token which it can use to exchange for a nullify token.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
