### PR TITLE
include missing error logs before exiting

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -56,17 +56,20 @@ func main() {
 	switch {
 	case args.DAST != nil && args.DAST.Path != "":
 		logger.Info(
-			"running fuzz test",
+			"running dast scan",
 			logger.String("path", args.DAST.Path),
 			logger.String("targetHost", args.DAST.TargetHost),
 		)
+
 		openAPISpec, err := lib.CreateOpenAPIFile(args.DAST.Path)
 		if err != nil {
+			logger.Error("failed to create openapi file", logger.Err(err))
 			os.Exit(1)
 		}
 
 		authHeaders, err := lib.ParseAuthHeaders(args.DAST.AuthHeaders)
 		if err != nil {
+			logger.Error("failed to parse auth headers", logger.Err(err))
 			os.Exit(1)
 		}
 

--- a/internal/dast/dast_local_scan.go
+++ b/internal/dast/dast_local_scan.go
@@ -33,6 +33,12 @@ type DASTLocalScanOutput struct {
 const ImageName = "dast-local"
 
 func DASTLocalScan(httpClient *http.Client, nullifyHost string, input *DASTLocalScanInput) error {
+	logger.Info(
+		"starting local scan",
+		logger.String("appName", input.AppName),
+		logger.String("host", input.TargetHost),
+	)
+
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return err

--- a/internal/dast/start_scan.go
+++ b/internal/dast/start_scan.go
@@ -27,6 +27,12 @@ type StartScanOutput struct {
 }
 
 func StartScan(httpClient *http.Client, nullifyHost string, input *StartScanInput) (*StartScanOutput, error) {
+	logger.Info(
+		"starting server side scan",
+		logger.String("appName", input.AppName),
+		logger.String("host", input.Host),
+	)
+
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return nil, err

--- a/internal/lib/auth_headers.go
+++ b/internal/lib/auth_headers.go
@@ -22,5 +22,6 @@ func ParseAuthHeaders(authHeaders []string) (map[string]string, error) {
 		headerValue := strings.TrimSpace(headerParts[1])
 		result[headerName] = headerValue
 	}
+
 	return result, nil
 }


### PR DESCRIPTION
## Description

There are some missing error log statements when we exit 1

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
