### PR TITLE
Add image pulling for nullify dast

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Options:
                          The repository name to create the Nullify issue dashboard in e.g. cli
   --header HEADER        List of headers for the DAST agent to authenticate with your API
   --local                Test the given app locally for bugs and vulnerabilities in private networks
-  --version VERSION      Version of the DAST local image that is used for scanning [default: 0.0.0]
+  --version VERSION      Version of the DAST local image that is used for scanning [default: latest]
 
 Global options:
   --host HOST            The base URL of your Nullify API instance [default: https://api.nullify.ai]
@@ -123,5 +123,5 @@ nullify dast \
 | **`github-repo`**  | The repository name to create the Nullify issue dashboard in, e.g. cli                              | `true`   |         |
 | **`header`**       | List of headers for the DAST agent to authenticate with your API                                    | `false`  |         |
 | **`local`**        | Test the given app locally for bugs and vulnerabilities in private networks                         | `false`  |         |
-| **`version`**      | Version of the DAST local image that is used for scanning [default: ]                               | `false`  |  0.0.0  |
+| **`version`**      | Version of the DAST local image that is used for scanning [default: ]                               | `false`  | latest  |
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Options:
                          The repository name to create the Nullify issue dashboard in e.g. cli
   --header HEADER        List of headers for the DAST agent to authenticate with your API
   --local                Test the given app locally for bugs and vulnerabilities in private networks
+  --version VERSION      Version of the DAST local image that is used for scanning [default: 0.0.0]
 
 Global options:
   --host HOST            The base URL of your Nullify API instance [default: https://api.nullify.ai]
@@ -122,4 +123,5 @@ nullify dast \
 | **`github-repo`**  | The repository name to create the Nullify issue dashboard in, e.g. cli                              | `true`   |         |
 | **`header`**       | List of headers for the DAST agent to authenticate with your API                                    | `false`  |         |
 | **`local`**        | Test the given app locally for bugs and vulnerabilities in private networks                         | `false`  |         |
+| **`version`**      | Version of the DAST local image that is used for scanning [default: ]                               | `false`  |  0.0.0  |
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strings"
 
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/dast"
@@ -20,7 +19,7 @@ type DAST struct {
 	GitHubOwner      string   `arg:"--github-owner" help:"The GitHub username or organisation to create the Nullify issue dashboard in e.g. nullify-platform"`
 	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
-	Local            string   `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
+	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
 }
 
 type args struct {
@@ -80,7 +79,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if strings.ToLower(args.DAST.Local) == "true" {
+		if args.DAST.Local {
 			err = dast.DASTLocalScan(httpClient, args.Host, &dast.DASTLocalScanInput{
 				AppName:     args.DAST.AppName,
 				Host:        args.Host,

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -20,7 +20,7 @@ type DAST struct {
 	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
 	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
-	Version          string   `arg:"--version" default:"0.0.0" help:"Version of the DAST local image that is used for scanning"`
+	Version          string   `arg:"--version" default:"latest" help:"Version of the DAST local image that is used for scanning"`
 }
 
 type args struct {

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -20,6 +20,7 @@ type DAST struct {
 	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
 	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
+	Version          string   `arg:"--version" default:"0.0.0" help:"Version of the DAST local image that is used for scanning"`
 }
 
 type args struct {
@@ -84,6 +85,7 @@ func main() {
 				AppName:     args.DAST.AppName,
 				Host:        args.Host,
 				TargetHost:  args.DAST.TargetHost,
+				Version:     args.DAST.Version,
 				OpenAPISpec: openAPISpec,
 				AuthSources: args.AuthSources,
 				AuthConfig: models.AuthConfig{

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strings"
 
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/dast"
@@ -19,7 +20,7 @@ type DAST struct {
 	GitHubOwner      string   `arg:"--github-owner" help:"The GitHub username or organisation to create the Nullify issue dashboard in e.g. nullify-platform"`
 	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
-	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
+	Local            string   `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
 }
 
 type args struct {
@@ -79,7 +80,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		if args.DAST.Local {
+		if strings.ToLower(args.DAST.Local) == "true" {
 			err = dast.DASTLocalScan(httpClient, args.Host, &dast.DASTLocalScanInput{
 				AppName:     args.DAST.AppName,
 				Host:        args.Host,


### PR DESCRIPTION
## Description

The nullify image is pulled from the ghcr in dast-local
## Linked Issues & PRs

- resolves https://github.com/Nullify-Platform/Death-Star/issues/361
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
