### PR TITLE
validate the nullify host

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/dast"
@@ -60,6 +61,14 @@ func main() {
 		logger.Error(
 			"failed to parse host",
 			logger.Err(err),
+			logger.String("host", args.Host),
+		)
+		os.Exit(1)
+	}
+
+	if !strings.HasPrefix(nullifyURL.Host, "api.") || !strings.HasSuffix(nullifyURL.Host, ".nullify.ai") {
+		logger.Error(
+			"invalid host, must be in the format api.<your-instance>.nullify.ai",
 			logger.String("host", args.Host),
 		)
 		os.Exit(1)

--- a/internal/dast/dast_local_scan.go
+++ b/internal/dast/dast_local_scan.go
@@ -32,7 +32,7 @@ type DASTLocalScanOutput struct {
 	ScanID string `json:"scanId"`
 }
 
-func DASTLocalScan(httpClient *http.Client, nullifyHost string, input *DASTLocalScanInput) error {
+func DASTLocalScan(httpClient *http.Client, input *DASTLocalScanInput) error {
 	logger.Info(
 		"starting local scan",
 		logger.String("appName", input.AppName),


### PR DESCRIPTION
## Description

Validate that the nullify host is a valid url and only extract the host from it (ignore scheme, path, query params etc)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
