### PR TITLE
create a nullify http client package and then move dast code to dast …

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -29,7 +29,6 @@ func main() {
 	var args args
 	p := arg.MustParse(&args)
 
-	// Configure logger
 	logLevel := "warn"
 	if args.Verbose {
 		logLevel = "info"

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -2,31 +2,23 @@ package client
 
 import (
 	"net/http"
-
-	"github.com/nullify-platform/logger/pkg/logger"
 )
 
-type authTransport struct {
-	token     string
-	transport http.RoundTripper
+type NullifyClient struct {
+	baseURL    string
+	httpClient *http.Client
 }
 
-func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set("Authorization", "Bearer "+t.token)
-	return t.transport.RoundTrip(req)
-}
-
-func NewHTTPClient(nullifyHost string, token string) (*http.Client, error) {
-
-	logger.Debug(
-		"using token",
-		logger.String("token", token),
-	)
-
-	return &http.Client{
+func NewNullifyClient(nullifyHost string, token string) *NullifyClient {
+	httpClient := &http.Client{
 		Transport: &authTransport{
 			token:     token,
 			transport: http.DefaultTransport,
 		},
-	}, nil
+	}
+
+	return &NullifyClient{
+		baseURL:    "https://" + nullifyHost,
+		httpClient: httpClient,
+	}
 }

--- a/internal/client/dast_start_cloud_scan.go
+++ b/internal/client/dast_start_cloud_scan.go
@@ -12,11 +12,10 @@ import (
 )
 
 type DASTStartCloudScanInput struct {
-	AppName    string `json:"appName"`
-	TargetHost string `json:"targetHost"`
-
-	OpenAPISpec map[string]interface{} `json:"openAPISpec"`
-	AuthConfig  models.AuthConfig      `json:"authConfig"`
+	AppName    string            `json:"appName"`
+	TargetHost string            `json:"targetHost"`
+	Spec       string            `json:"spec"`
+	AuthConfig models.AuthConfig `json:"authConfig"`
 
 	// TODO deprecate
 	Host string `json:"host"`

--- a/internal/client/dast_start_cloud_scan.go
+++ b/internal/client/dast_start_cloud_scan.go
@@ -12,10 +12,10 @@ import (
 )
 
 type DASTStartCloudScanInput struct {
-	AppName    string            `json:"appName"`
-	TargetHost string            `json:"targetHost"`
-	Spec       string            `json:"spec"`
-	AuthConfig models.AuthConfig `json:"authConfig"`
+	AppName     string            `json:"appName"`
+	TargetHost  string            `json:"targetHost"`
+	OpenAPISpec map[string]any    `json:"openAPISpec"`
+	AuthConfig  models.AuthConfig `json:"authConfig"`
 
 	// TODO deprecate
 	Host string `json:"host"`

--- a/internal/client/transport.go
+++ b/internal/client/transport.go
@@ -1,0 +1,17 @@
+package client
+
+import "net/http"
+
+type authTransport struct {
+	nullifyHost string
+	token       string
+	transport   http.RoundTripper
+}
+
+func (t *authTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = "https"
+	req.URL.Host = t.nullifyHost
+	req.Host = t.nullifyHost
+	req.Header.Set("Authorization", "Bearer "+t.token)
+	return t.transport.RoundTrip(req)
+}

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -1,8 +1,6 @@
 package dast
 
 import (
-	"os"
-
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/lib"
 	"github.com/nullify-platform/cli/internal/models"
@@ -24,13 +22,13 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 	spec, err := lib.CreateOpenAPIFile(dast.Path)
 	if err != nil {
 		logger.Error("failed to create openapi file", logger.Err(err))
-		os.Exit(1)
+		return err
 	}
 
 	authHeaders, err := lib.ParseAuthHeaders(dast.AuthHeaders)
 	if err != nil {
 		logger.Error("failed to parse auth headers", logger.Err(err))
-		os.Exit(1)
+		return err
 	}
 
 	if dast.Local {
@@ -52,7 +50,7 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 		})
 		if err != nil {
 			logger.Error("failed to send request", logger.Err(err))
-			os.Exit(1)
+			return err
 		}
 	} else {
 		logger.Info("starting server side scan")
@@ -73,7 +71,7 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 		})
 		if err != nil {
 			logger.Error("failed to send request", logger.Err(err))
-			os.Exit(1)
+			return err
 		}
 
 		logger.Info("request sent successfully", logger.String("scanId", out.ScanID))

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -1,0 +1,83 @@
+package dast
+
+import (
+	"os"
+
+	"github.com/nullify-platform/cli/internal/client"
+	"github.com/nullify-platform/cli/internal/lib"
+	"github.com/nullify-platform/cli/internal/models"
+	"github.com/nullify-platform/logger/pkg/logger"
+)
+
+type DAST struct {
+	AppName          string   `arg:"--app-name" help:"The unique name of the app to be scanned, you can set this to anything e.g. Core API"`
+	Path             string   `arg:"--spec-path" help:"The file path to the OpenAPI file (both yaml and json are supported) e.g. ./openapi.yaml"`
+	TargetHost       string   `arg:"--target-host" help:"The base URL of the API to be scanned e.g. https://api.nullify.ai"`
+	GitHubOwner      string   `arg:"--github-owner" help:"The GitHub username or organisation to create the Nullify issue dashboard in e.g. nullify-platform"`
+	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
+	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
+	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
+	Version          string   `arg:"--version" default:"latest" help:"Version of the DAST local image that is used for scanning"`
+}
+
+func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
+	openAPISpec, err := lib.CreateOpenAPIFile(dast.Path)
+	if err != nil {
+		logger.Error("failed to create openapi file", logger.Err(err))
+		os.Exit(1)
+	}
+
+	authHeaders, err := lib.ParseAuthHeaders(dast.AuthHeaders)
+	if err != nil {
+		logger.Error("failed to parse auth headers", logger.Err(err))
+		os.Exit(1)
+	}
+
+	if dast.Local {
+		logger.Info("starting local scan")
+		err = StartLocalScan(nullifyClient, &StartLocalScanInput{
+			AppName:     dast.AppName,
+			TargetHost:  dast.TargetHost,
+			Version:     dast.Version,
+			OpenAPISpec: openAPISpec,
+			AuthConfig: models.AuthConfig{
+				Headers: authHeaders,
+			},
+			RequestProvider: models.RequestProvider{
+				GitHubOwner: dast.GitHubOwner,
+			},
+			RequestDashboardTarget: models.RequestDashboardTarget{
+				GitHubRepository: dast.GitHubRepository,
+			},
+		})
+		if err != nil {
+			logger.Error("failed to send request", logger.Err(err))
+			os.Exit(1)
+		}
+	} else {
+		logger.Info("starting server side scan")
+		out, err := nullifyClient.DASTStartCloudScan(&client.DASTStartCloudScanInput{
+			AppName:     dast.AppName,
+			Host:        dast.TargetHost,
+			TargetHost:  dast.TargetHost,
+			OpenAPISpec: openAPISpec,
+			AuthConfig: models.AuthConfig{
+				Headers: authHeaders,
+			},
+			RequestProvider: models.RequestProvider{
+				GitHubOwner: dast.GitHubOwner,
+			},
+			RequestDashboardTarget: models.RequestDashboardTarget{
+				GitHubRepository: dast.GitHubRepository,
+			},
+		})
+		if err != nil {
+			logger.Error("failed to send request", logger.Err(err))
+			os.Exit(1)
+		}
+
+		logger.Info("request sent successfully", logger.String("scanId", out.ScanID))
+	}
+
+	return nil
+}

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -36,10 +36,10 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 	if dast.Local {
 		logger.Info("starting local scan")
 		err = StartLocalScan(nullifyClient, &StartLocalScanInput{
-			AppName:    dast.AppName,
-			TargetHost: dast.TargetHost,
-			Version:    dast.Version,
-			Spec:       spec,
+			AppName:     dast.AppName,
+			TargetHost:  dast.TargetHost,
+			Version:     dast.Version,
+			OpenAPISpec: spec,
 			AuthConfig: models.AuthConfig{
 				Headers: authHeaders,
 			},
@@ -57,10 +57,10 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 	} else {
 		logger.Info("starting server side scan")
 		out, err := nullifyClient.DASTStartCloudScan(&client.DASTStartCloudScanInput{
-			AppName:    dast.AppName,
-			Host:       dast.TargetHost,
-			TargetHost: dast.TargetHost,
-			Spec:       spec,
+			AppName:     dast.AppName,
+			Host:        dast.TargetHost,
+			TargetHost:  dast.TargetHost,
+			OpenAPISpec: spec,
 			AuthConfig: models.AuthConfig{
 				Headers: authHeaders,
 			},

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -21,7 +21,7 @@ type DAST struct {
 }
 
 func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
-	openAPISpec, err := lib.CreateOpenAPIFile(dast.Path)
+	spec, err := lib.CreateOpenAPIFile(dast.Path)
 	if err != nil {
 		logger.Error("failed to create openapi file", logger.Err(err))
 		os.Exit(1)
@@ -36,10 +36,10 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 	if dast.Local {
 		logger.Info("starting local scan")
 		err = StartLocalScan(nullifyClient, &StartLocalScanInput{
-			AppName:     dast.AppName,
-			TargetHost:  dast.TargetHost,
-			Version:     dast.Version,
-			OpenAPISpec: openAPISpec,
+			AppName:    dast.AppName,
+			TargetHost: dast.TargetHost,
+			Version:    dast.Version,
+			Spec:       spec,
 			AuthConfig: models.AuthConfig{
 				Headers: authHeaders,
 			},
@@ -57,10 +57,10 @@ func StartDASTScan(dast *DAST, nullifyClient *client.NullifyClient) error {
 	} else {
 		logger.Info("starting server side scan")
 		out, err := nullifyClient.DASTStartCloudScan(&client.DASTStartCloudScanInput{
-			AppName:     dast.AppName,
-			Host:        dast.TargetHost,
-			TargetHost:  dast.TargetHost,
-			OpenAPISpec: openAPISpec,
+			AppName:    dast.AppName,
+			Host:       dast.TargetHost,
+			TargetHost: dast.TargetHost,
+			Spec:       spec,
 			AuthConfig: models.AuthConfig{
 				Headers: authHeaders,
 			},

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -5,20 +5,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
+	docker "github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/stdcopy"
+	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/models"
 	"github.com/nullify-platform/logger/pkg/logger"
 )
 
 type StartLocalScanInput struct {
 	AppName      string                 `json:"appName"`
-	Host         string                 `json:"host"`
 	TargetHost   string                 `json:"targetHost"`
 	Version      string                 `json:"version"`
 	OpenAPISpec  map[string]interface{} `json:"openAPISpec"`
@@ -33,7 +32,7 @@ type StartLocalScanOutput struct {
 	ScanID string `json:"scanId"`
 }
 
-func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
+func StartLocalScan(nullifyClient *client.NullifyClient, input *StartLocalScanInput) error {
 	logger.Info(
 		"starting local scan",
 		logger.String("appName", input.AppName),
@@ -47,7 +46,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 
 	ctx := context.Background()
 
-	client, err := client.NewClientWithOpts(client.FromEnv, client.WithAPIVersionNegotiation())
+	dockerclient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
 		logger.Error(
 			"unable to create new docker client",
@@ -55,11 +54,11 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 		)
 		return err
 	}
-	defer client.Close()
+	defer dockerclient.Close()
 
 	imageRef := fmt.Sprintf("ghcr.io/nullify-platform/dast-local:%s", input.Version)
 
-	pullOut, err := client.ImagePull(ctx, imageRef, types.ImagePullOptions{})
+	pullOut, err := dockerclient.ImagePull(ctx, imageRef, types.ImagePullOptions{})
 	if err != nil {
 		logger.Error(
 			"unable to pull image from nullify platform ghrc",
@@ -78,7 +77,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 		return err
 	}
 
-	containerResp, err := client.ContainerCreate(ctx, &container.Config{
+	containerResp, err := dockerclient.ContainerCreate(ctx, &container.Config{
 		Image: imageRef,
 		Cmd:   []string{string(requestBody)},
 	}, nil, nil, nil, "")
@@ -91,7 +90,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 	}
 
 	defer func() {
-		if err = client.ContainerRemove(ctx, containerResp.ID, container.RemoveOptions{RemoveVolumes: true, RemoveLinks: false, Force: true}); err != nil {
+		if err = dockerclient.ContainerRemove(ctx, containerResp.ID, container.RemoveOptions{RemoveVolumes: true, RemoveLinks: false, Force: true}); err != nil {
 			logger.Error(
 				"unable to remove container",
 				logger.Err(err),
@@ -99,7 +98,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 		}
 	}()
 
-	if err = client.ContainerStart(ctx, containerResp.ID, container.StartOptions{}); err != nil {
+	if err = dockerclient.ContainerStart(ctx, containerResp.ID, container.StartOptions{}); err != nil {
 		logger.Error(
 			"unable to start docker container",
 			logger.Err(err),
@@ -107,7 +106,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 		return err
 	}
 
-	statusCh, errCh := client.ContainerWait(ctx, containerResp.ID, container.WaitConditionNotRunning)
+	statusCh, errCh := dockerclient.ContainerWait(ctx, containerResp.ID, container.WaitConditionNotRunning)
 	select {
 	case err := <-errCh:
 		if err != nil {
@@ -120,7 +119,7 @@ func StartLocalScan(httpClient *http.Client, input *StartLocalScanInput) error {
 	case <-statusCh:
 	}
 
-	logsOut, err := client.ContainerLogs(ctx, containerResp.ID, container.LogsOptions{ShowStdout: true})
+	logsOut, err := dockerclient.ContainerLogs(ctx, containerResp.ID, container.LogsOptions{ShowStdout: true})
 	if err != nil {
 		logger.Error(
 			"unable to create docker container logs",

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -20,7 +20,7 @@ type StartLocalScanInput struct {
 	AppName      string            `json:"appName"`
 	TargetHost   string            `json:"targetHost"`
 	Version      string            `json:"version"`
-	Spec         string            `json:"openAPISpec"`
+	OpenAPISpec  map[string]any    `json:"openAPISpec"`
 	AuthConfig   models.AuthConfig `json:"authConfig"`
 	NullifyToken string            `json:"nullifyToken"`
 

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -17,12 +17,12 @@ import (
 )
 
 type StartLocalScanInput struct {
-	AppName      string                 `json:"appName"`
-	TargetHost   string                 `json:"targetHost"`
-	Version      string                 `json:"version"`
-	OpenAPISpec  map[string]interface{} `json:"openAPISpec"`
-	AuthConfig   models.AuthConfig      `json:"authConfig"`
-	NullifyToken string                 `json:"nullifyToken"`
+	AppName      string            `json:"appName"`
+	TargetHost   string            `json:"targetHost"`
+	Version      string            `json:"version"`
+	Spec         string            `json:"openAPISpec"`
+	AuthConfig   models.AuthConfig `json:"authConfig"`
+	NullifyToken string            `json:"nullifyToken"`
 
 	models.RequestProvider
 	models.RequestDashboardTarget

--- a/internal/lib/openapi.go
+++ b/internal/lib/openapi.go
@@ -51,6 +51,9 @@ func CreateOpenAPIFile(filePath string) (map[string]any, error) {
 	return openAPISpec, nil
 }
 
+// convert converts the map[interface{}]interface{} to map[string]interface{}.
+// this is required for YAML spec files as the keys are of type interface{}
+// because YAML keys can be either string or int but JSON only supports strings
 func convert(i interface{}) interface{} {
 	switch x := i.(type) {
 	case map[interface{}]interface{}:

--- a/internal/lib/openapi.go
+++ b/internal/lib/openapi.go
@@ -10,7 +10,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func CreateOpenAPIFile(filePath string) (map[string]interface{}, error) {
+func CreateOpenAPIFile(filePath string) (string, error) {
 	filePath = filepath.Clean(filePath)
 	data, err := os.Open(filePath)
 	if err != nil {
@@ -19,23 +19,25 @@ func CreateOpenAPIFile(filePath string) (map[string]interface{}, error) {
 			logger.Err(err),
 			logger.String("path", filePath),
 		)
-		return nil, err
+		return "", err
 	}
+
 	fileData, err := io.ReadAll(data)
 	if err != nil {
 		logger.Error(
 			"failed to read file",
 			logger.Err(err),
 		)
-		return nil, err
+		return "", err
 	}
 
 	var openAPISpec map[string]interface{}
 	if err := json.Unmarshal(fileData, &openAPISpec); err != nil {
 		if err := yaml.Unmarshal(fileData, &openAPISpec); err != nil {
-			logger.Error("please provide either a json or yaml file")
-			return nil, err
+			logger.Error("please provide a valid json or yaml openapi spec file")
+			return "", err
 		}
 	}
-	return openAPISpec, nil
+
+	return string(fileData), nil
 }

--- a/internal/lib/openapi_test.go
+++ b/internal/lib/openapi_test.go
@@ -1,0 +1,54 @@
+package lib
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/nullify-platform/cli/internal/client"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateOpenAPIJSON(t *testing.T) {
+	spec, err := CreateOpenAPIFile("test/openapi.json")
+	require.NoError(t, err)
+
+	require.Equal(t, "3.0.0", spec["openapi"])
+
+	input := client.DASTStartCloudScanInput{
+		AppName:     "test",
+		Host:        "test.com",
+		OpenAPISpec: spec,
+	}
+
+	requestBody, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var input2 client.DASTStartCloudScanInput
+	err = json.Unmarshal(requestBody, &input2)
+	require.NoError(t, err)
+
+	require.Equal(t, input, input2)
+}
+
+func TestCreateOpenAPIYAML(t *testing.T) {
+	spec, err := CreateOpenAPIFile("test/openapi.yml")
+	require.NoError(t, err)
+
+	require.Equal(t, "3.0.0", spec["openapi"])
+
+	input := client.DASTStartCloudScanInput{
+		AppName:     "test",
+		Host:        "test.com",
+		OpenAPISpec: spec,
+	}
+
+	requestBody, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var input2 client.DASTStartCloudScanInput
+	err = json.Unmarshal(requestBody, &input2)
+	require.NoError(t, err)
+
+	require.Equal(t, input, input2)
+}

--- a/internal/lib/test/openapi.json
+++ b/internal/lib/test/openapi.json
@@ -1,0 +1,167 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+      "title": "Simple API overview",
+      "version": "2.0.0"
+    },
+    "paths": {
+      "/": {
+        "get": {
+          "operationId": "listVersionsv2",
+          "summary": "List API versions",
+          "responses": {
+            "200": {
+              "description": "200 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "foo": {
+                      "value": {
+                        "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                              {
+                                "href": "http://127.0.0.1:8774/v2/",
+                                "rel": "self"
+                              }
+                            ]
+                          },
+                          {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                              {
+                                "href": "http://127.0.0.1:8774/v3/",
+                                "rel": "self"
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "300": {
+              "description": "300 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "foo": {
+                      "value": "{\n \"versions\": [\n       {\n         \"status\": \"CURRENT\",\n         \"updated\": \"2011-01-21T11:33:21Z\",\n         \"id\": \"v2.0\",\n         \"links\": [\n             {\n                 \"href\": \"http://127.0.0.1:8774/v2/\",\n                 \"rel\": \"self\"\n             }\n         ]\n     },\n     {\n         \"status\": \"EXPERIMENTAL\",\n         \"updated\": \"2013-07-23T11:33:21Z\",\n         \"id\": \"v3.0\",\n         \"links\": [\n             {\n                 \"href\": \"http://127.0.0.1:8774/v3/\",\n                 \"rel\": \"self\"\n             }\n         ]\n     }\n ]\n}\n"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "/v2": {
+        "get": {
+          "operationId": "getVersionDetailsv2",
+          "summary": "Show API version details",
+          "responses": {
+            "200": {
+              "description": "200 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "foo": {
+                      "value": {
+                        "version": {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "media-types": [
+                            {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                            },
+                            {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                            }
+                          ],
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                            },
+                            {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                            },
+                            {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                            },
+                            {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "203": {
+              "description": "203 response",
+              "content": {
+                "application/json": {
+                  "examples": {
+                    "foo": {
+                      "value": {
+                        "version": {
+                          "status": "CURRENT",
+                          "updated": "2011-01-21T11:33:21Z",
+                          "media-types": [
+                            {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                            },
+                            {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                            }
+                          ],
+                          "id": "v2.0",
+                          "links": [
+                            {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                            },
+                            {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                            },
+                            {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/internal/lib/test/openapi.yml
+++ b/internal/lib/test/openapi.yml
@@ -1,0 +1,170 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: 2.0.0
+paths:
+  /:
+    get:
+      operationId: listVersionsv2
+      summary: List API versions
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json:
+              examples: 
+                foo:
+                  value:
+                    {
+                      "versions": [
+                        {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                      ]
+                    }
+        '300':
+          description: |-
+            300 response
+          content:
+            application/json: 
+              examples: 
+                foo:
+                  value: |
+                   {
+                    "versions": [
+                          {
+                            "status": "CURRENT",
+                            "updated": "2011-01-21T11:33:21Z",
+                            "id": "v2.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v2/",
+                                    "rel": "self"
+                                }
+                            ]
+                        },
+                        {
+                            "status": "EXPERIMENTAL",
+                            "updated": "2013-07-23T11:33:21Z",
+                            "id": "v3.0",
+                            "links": [
+                                {
+                                    "href": "http://127.0.0.1:8774/v3/",
+                                    "rel": "self"
+                                }
+                            ]
+                        }
+                    ]
+                   }
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        '200':
+          description: |-
+            200 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://127.0.0.1:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          },
+                          {
+                            "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                            "type": "application/vnd.sun.wadl+xml",
+                            "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }
+        '203':
+          description: |-
+            203 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  value:
+                    {
+                      "version": {
+                        "status": "CURRENT",
+                        "updated": "2011-01-21T11:33:21Z",
+                        "media-types": [
+                          {
+                              "base": "application/xml",
+                              "type": "application/vnd.openstack.compute+xml;version=2"
+                          },
+                          {
+                              "base": "application/json",
+                              "type": "application/vnd.openstack.compute+json;version=2"
+                          }
+                        ],
+                        "id": "v2.0",
+                        "links": [
+                          {
+                              "href": "http://23.253.228.211:8774/v2/",
+                              "rel": "self"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/os-compute-devguide-2.pdf",
+                              "type": "application/pdf",
+                              "rel": "describedby"
+                          },
+                          {
+                              "href": "http://docs.openstack.org/api/openstack-compute/2/wadl/os-compute-2.wadl",
+                              "type": "application/vnd.sun.wadl+xml",
+                              "rel": "describedby"
+                          }
+                        ]
+                      }
+                    }


### PR DESCRIPTION
…package

## Description

- create an `internal/client` package for the nullify client
- move all dast code to the `internal/dast` package
- fix yaml parsing and marshalling into json for the API

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
