### PR TITLE
Use the stdin/stdout interface for the local DAST image

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	switch {
 	case args.DAST != nil && args.DAST.Path != "":
-		err = dast.StartDASTScan(ctx, args.DAST, nullifyClient)
+		err = dast.StartDASTScan(ctx, args.DAST, nullifyClient, logLevel)
 		if err != nil {
 			logger.Error(
 				"failed to start dast scan",

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/nullify-platform/cli/internal/client"
@@ -26,6 +27,8 @@ func (args) Version() string {
 }
 
 func main() {
+	ctx := context.TODO()
+
 	var args args
 	p := arg.MustParse(&args)
 
@@ -64,7 +67,7 @@ func main() {
 
 	switch {
 	case args.DAST != nil && args.DAST.Path != "":
-		err = dast.StartDASTScan(args.DAST, nullifyClient)
+		err = dast.StartDASTScan(ctx, args.DAST, nullifyClient)
 		if err != nil {
 			logger.Error(
 				"failed to start dast scan",

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -14,8 +14,9 @@ type NullifyClient struct {
 func NewNullifyClient(nullifyHost string, token string) *NullifyClient {
 	httpClient := &http.Client{
 		Transport: &authTransport{
-			token:     token,
-			transport: http.DefaultTransport,
+			nullifyHost: nullifyHost,
+			token:       token,
+			transport:   http.DefaultTransport,
 		},
 	}
 

--- a/internal/client/dast_cloud_scan_start.go
+++ b/internal/client/dast_cloud_scan_start.go
@@ -28,7 +28,7 @@ type DASTStartCloudScanOutput struct {
 	ScanID string `json:"scanId"`
 }
 
-func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*DASTStartCloudScanOutput, error) {
+func (c *NullifyClient) DASTStartCloudScan(githubOwner string, input *DASTStartCloudScanInput) (*DASTStartCloudScanOutput, error) {
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*DAS
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s/dast/scans", c.BaseURL),
+		fmt.Sprintf("%s/dast/scans??githubOwner=%s", c.BaseURL, githubOwner),
 		strings.NewReader(string(requestBody)),
 	)
 	if err != nil {

--- a/internal/client/dast_cloud_scan_start.go
+++ b/internal/client/dast_cloud_scan_start.go
@@ -1,0 +1,80 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/nullify-platform/cli/internal/models"
+	"github.com/nullify-platform/logger/pkg/logger"
+)
+
+type DASTStartCloudScanInput struct {
+	AppName     string            `json:"appName"`
+	TargetHost  string            `json:"targetHost"`
+	OpenAPISpec map[string]any    `json:"openAPISpec"`
+	AuthConfig  models.AuthConfig `json:"authConfig"`
+
+	// TODO deprecate
+	Host string `json:"host"`
+
+	models.RequestProvider
+	models.RequestDashboardTarget
+}
+
+type DASTStartCloudScanOutput struct {
+	ScanID string `json:"scanId"`
+}
+
+func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*DASTStartCloudScanOutput, error) {
+	requestBody, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(
+		"POST",
+		fmt.Sprintf("%s/dast/scans", c.BaseURL),
+		strings.NewReader(string(requestBody)),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, HandleError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Debug(
+		"nullify dast response",
+		logger.String("status", resp.Status),
+		logger.String("body", string(body)),
+	)
+
+	var output DASTStartCloudScanOutput
+	err = json.Unmarshal(body, &output)
+	if err != nil {
+		logger.Error(
+			"error in unmarshalling response",
+			logger.Err(err),
+		)
+		return nil, err
+	}
+
+	return &output, nil
+}

--- a/internal/client/dast_external_scan_create.go
+++ b/internal/client/dast_external_scan_create.go
@@ -28,15 +28,21 @@ type DASTCreateExternalScanOutput struct {
 	ScanID string `json:"scanId"`
 }
 
-func (c *NullifyClient) DASTCreateExternalScan(input *DASTCreateExternalScanInput) (*DASTCreateExternalScanOutput, error) {
+func (c *NullifyClient) DASTCreateExternalScan(githubOwner string, input *DASTCreateExternalScanInput) (*DASTCreateExternalScanOutput, error) {
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return nil, err
 	}
 
+	logger.Info(
+		"creating external scan",
+		logger.String("appName", input.AppName),
+		logger.String("baseURL", c.BaseURL),
+	)
+
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s/dast/external", c.BaseURL),
+		fmt.Sprintf("%s/dast/external?githubOwner=%s", c.BaseURL, githubOwner),
 		strings.NewReader(string(requestBody)),
 	)
 	if err != nil {

--- a/internal/client/dast_external_scan_create.go
+++ b/internal/client/dast_external_scan_create.go
@@ -6,29 +6,29 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/nullify-platform/cli/internal/models"
 	"github.com/nullify-platform/logger/pkg/logger"
 )
 
-type DASTStartCloudScanInput struct {
-	AppName     string            `json:"appName"`
-	TargetHost  string            `json:"targetHost"`
-	OpenAPISpec map[string]any    `json:"openAPISpec"`
-	AuthConfig  models.AuthConfig `json:"authConfig"`
+type DASTCreateExternalScanInput struct {
+	AppName string `json:"appName"`
 
-	// TODO deprecate
-	Host string `json:"host"`
+	Progress  *int       `json:"progress"`
+	Status    *string    `json:"status"`
+	StartTime *time.Time `json:"startTime"`
+	EndTime   *time.Time `json:"endTime"`
 
 	models.RequestProvider
 	models.RequestDashboardTarget
 }
 
-type StartCloudScanOutput struct {
+type DASTCreateExternalScanOutput struct {
 	ScanID string `json:"scanId"`
 }
 
-func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*StartCloudScanOutput, error) {
+func (c *NullifyClient) DASTCreateExternalScan(input *DASTCreateExternalScanInput) (*DASTCreateExternalScanOutput, error) {
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return nil, err
@@ -36,7 +36,7 @@ func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*Sta
 
 	req, err := http.NewRequest(
 		"POST",
-		fmt.Sprintf("%s/dast/scans", c.BaseURL),
+		fmt.Sprintf("%s/dast/external", c.BaseURL),
 		strings.NewReader(string(requestBody)),
 	)
 	if err != nil {
@@ -66,7 +66,7 @@ func (c *NullifyClient) DASTStartCloudScan(input *DASTStartCloudScanInput) (*Sta
 		logger.String("body", string(body)),
 	)
 
-	var output StartCloudScanOutput
+	var output DASTCreateExternalScanOutput
 	err = json.Unmarshal(body, &output)
 	if err != nil {
 		logger.Error(

--- a/internal/client/dast_external_scan_update.go
+++ b/internal/client/dast_external_scan_update.go
@@ -19,7 +19,7 @@ type DASTUpdateExternalScanInput struct {
 	*models.RequestDashboardTarget
 }
 
-func (c *NullifyClient) DASTUpdateExternalScan(scanID string, input *DASTUpdateExternalScanInput) error {
+func (c *NullifyClient) DASTUpdateExternalScan(githubOwner string, scanID string, input *DASTUpdateExternalScanInput) error {
 	requestBody, err := json.Marshal(input)
 	if err != nil {
 		return err
@@ -27,7 +27,7 @@ func (c *NullifyClient) DASTUpdateExternalScan(scanID string, input *DASTUpdateE
 
 	req, err := http.NewRequest(
 		"PATCH",
-		fmt.Sprintf("%s/dast/external/%s", c.BaseURL, scanID),
+		fmt.Sprintf("%s/dast/external/%s?githubOwner=%s", c.BaseURL, scanID, githubOwner),
 		strings.NewReader(string(requestBody)),
 	)
 	if err != nil {

--- a/internal/client/dast_external_scan_update.go
+++ b/internal/client/dast_external_scan_update.go
@@ -1,0 +1,61 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/nullify-platform/cli/internal/models"
+	"github.com/nullify-platform/logger/pkg/logger"
+)
+
+type DASTUpdateExternalScanInput struct {
+	Progress *int                 `json:"progress"`
+	Status   *string              `json:"status"`
+	Findings []models.DASTFinding `json:"findings"`
+
+	*models.RequestDashboardTarget
+}
+
+func (c *NullifyClient) DASTUpdateExternalScan(scanID string, input *DASTUpdateExternalScanInput) error {
+	requestBody, err := json.Marshal(input)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(
+		"PATCH",
+		fmt.Sprintf("%s/dast/external/%s", c.BaseURL, scanID),
+		strings.NewReader(string(requestBody)),
+	)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.HttpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return HandleError(resp)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	logger.Debug(
+		"nullify dast response",
+		logger.String("status", resp.Status),
+		logger.String("body", string(body)),
+	)
+
+	return nil
+}

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -22,7 +22,7 @@ type DAST struct {
 	GitHubRepository string `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 }
 
-func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.NullifyClient) error {
+func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.NullifyClient, logLevel string) error {
 	spec, err := lib.CreateOpenAPIFile(dast.Path)
 	if err != nil {
 		logger.Error("failed to create openapi file", logger.Err(err))
@@ -59,6 +59,7 @@ func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.Nullif
 				},
 			},
 			dast.ForcePullImage,
+			logLevel,
 		)
 		if err != nil {
 			logger.Error("failed to send request", logger.Err(err))

--- a/internal/dast/dast.go
+++ b/internal/dast/dast.go
@@ -10,15 +10,16 @@ import (
 )
 
 type DAST struct {
-	AppName          string   `arg:"--app-name" help:"The unique name of the app to be scanned, you can set this to anything e.g. Core API"`
-	Path             string   `arg:"--spec-path" help:"The file path to the OpenAPI file (both yaml and json are supported) e.g. ./openapi.yaml"`
-	TargetHost       string   `arg:"--target-host" help:"The base URL of the API to be scanned e.g. https://api.nullify.ai"`
-	GitHubOwner      string   `arg:"--github-owner" help:"The GitHub username or organisation to create the Nullify issue dashboard in e.g. nullify-platform"`
-	GitHubRepository string   `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
-	AuthHeaders      []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
-	Local            bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
-	Version          string   `arg:"--version" default:"latest" help:"Version of the DAST local image that is used for scanning"`
-	ForcePullImage   bool     `arg:"--pull" help:"Force a docker pull of the latest version of the DAST local image"`
+	AppName        string   `arg:"--app-name" help:"The unique name of the app to be scanned, you can set this to anything e.g. Core API"`
+	Path           string   `arg:"--spec-path" help:"The file path to the OpenAPI file (both yaml and json are supported) e.g. ./openapi.yaml"`
+	TargetHost     string   `arg:"--target-host" help:"The base URL of the API to be scanned e.g. https://api.nullify.ai"`
+	AuthHeaders    []string `arg:"--header" help:"List of headers for the DAST agent to authenticate with your API"`
+	Local          bool     `arg:"--local" help:"Test the given app locally for bugs and vulnerabilities in private networks"`
+	Version        string   `arg:"--version" default:"latest" help:"Version of the DAST local image that is used for scanning"`
+	ForcePullImage bool     `arg:"--pull" help:"Force a docker pull of the latest version of the DAST local image"`
+
+	GitHubOwner      string `arg:"--github-owner" help:"The GitHub username or organisation"`
+	GitHubRepository string `arg:"--github-repo" help:"The repository name to create the Nullify issue dashboard in e.g. cli"`
 }
 
 func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.NullifyClient) error {
@@ -39,6 +40,7 @@ func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.Nullif
 		err = StartExternalScan(
 			ctx,
 			nullifyClient,
+			dast.GitHubOwner,
 			&DASTExternalScanInput{
 				AppName:     dast.AppName,
 				Host:        nullifyClient.Host,
@@ -64,7 +66,7 @@ func StartDASTScan(ctx context.Context, dast *DAST, nullifyClient *client.Nullif
 		}
 	} else {
 		logger.Info("starting server side scan")
-		out, err := nullifyClient.DASTStartCloudScan(&client.DASTStartCloudScanInput{
+		out, err := nullifyClient.DASTStartCloudScan(dast.GitHubOwner, &client.DASTStartCloudScanInput{
 			AppName:     dast.AppName,
 			Host:        dast.TargetHost,
 			TargetHost:  dast.TargetHost,

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -82,6 +82,9 @@ func StartExternalScan(
 	return nil
 }
 
+const initialBufferSize = 64 * 1024
+const maxBufferSize = 1024 * 1024
+
 func runDASTInDocker(
 	ctx context.Context,
 	input *DASTExternalScanInput,
@@ -223,8 +226,8 @@ func runDASTInDocker(
 	var lastLine string
 
 	scanner := bufio.NewScanner(logsOut)
-	buf := make([]byte, 0, 64*1024)
-	scanner.Buffer(buf, 1024*1024)
+	buf := make([]byte, 0, initialBufferSize)
+	scanner.Buffer(buf, maxBufferSize)
 	for scanner.Scan() {
 		if lastLine != "" {
 			var output map[string]any

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -36,6 +36,7 @@ type DASTExternalScanOutput struct {
 func StartExternalScan(
 	ctx context.Context,
 	nullifyClient *client.NullifyClient,
+	githubOwner string,
 	input *DASTExternalScanInput,
 	forcePullImage bool,
 ) error {
@@ -45,7 +46,7 @@ func StartExternalScan(
 		logger.String("host", input.TargetHost),
 	)
 
-	externalDASTScan, err := nullifyClient.DASTCreateExternalScan(&client.DASTCreateExternalScanInput{
+	externalDASTScan, err := nullifyClient.DASTCreateExternalScan(githubOwner, &client.DASTCreateExternalScanInput{
 		AppName: input.AppName,
 	})
 	if err != nil {
@@ -66,7 +67,7 @@ func StartExternalScan(
 		logger.Int("findingsCount", len(findings)),
 	)
 
-	err = nullifyClient.DASTUpdateExternalScan(externalDASTScan.ScanID, &client.DASTUpdateExternalScanInput{
+	err = nullifyClient.DASTUpdateExternalScan(githubOwner, externalDASTScan.ScanID, &client.DASTUpdateExternalScanInput{
 		Findings: findings,
 	})
 	if err != nil {

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -39,6 +39,7 @@ func StartExternalScan(
 	githubOwner string,
 	input *DASTExternalScanInput,
 	forcePullImage bool,
+	logLevel string,
 ) error {
 	logger.Info(
 		"starting local scan",
@@ -57,7 +58,7 @@ func StartExternalScan(
 		return err
 	}
 
-	findings, err := runDASTInDocker(ctx, input, forcePullImage)
+	findings, err := runDASTInDocker(ctx, input, forcePullImage, logLevel)
 	if err != nil {
 		return err
 	}
@@ -85,6 +86,7 @@ func runDASTInDocker(
 	ctx context.Context,
 	input *DASTExternalScanInput,
 	forcePullImage bool,
+	logLevel string,
 ) ([]models.DASTFinding, error) {
 	requestBody, err := json.Marshal(input)
 	if err != nil {
@@ -144,6 +146,9 @@ func runDASTInDocker(
 			AttachStdin:  true,
 			AttachStdout: true,
 			AttachStderr: true,
+			Env: []string{
+				fmt.Sprintf("LOG_LEVEL=%s", logLevel),
+			},
 		},
 		&container.HostConfig{
 			AutoRemove:  true,

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -1,6 +1,7 @@
 package dast
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -10,13 +11,12 @@ import (
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	docker "github.com/docker/docker/client"
-	"github.com/docker/docker/pkg/stdcopy"
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/models"
 	"github.com/nullify-platform/logger/pkg/logger"
 )
 
-type StartLocalScanInput struct {
+type DASTExternalScanInput struct {
 	AppName      string            `json:"appName"`
 	Host         string            `json:"host"`
 	TargetHost   string            `json:"targetHost"`
@@ -29,23 +29,66 @@ type StartLocalScanInput struct {
 	models.RequestDashboardTarget
 }
 
-type StartLocalScanOutput struct {
-	ScanID string `json:"scanId"`
+type DASTExternalScanOutput struct {
+	Findings []models.DASTFinding `json:"findings"`
 }
 
-func StartLocalScan(nullifyClient *client.NullifyClient, input *StartLocalScanInput) error {
+func StartExternalScan(
+	ctx context.Context,
+	nullifyClient *client.NullifyClient,
+	input *DASTExternalScanInput,
+	forcePullImage bool,
+) error {
 	logger.Info(
 		"starting local scan",
 		logger.String("appName", input.AppName),
 		logger.String("host", input.TargetHost),
 	)
 
-	requestBody, err := json.Marshal(input)
+	externalDASTScan, err := nullifyClient.DASTCreateExternalScan(&client.DASTCreateExternalScanInput{
+		AppName: input.AppName,
+	})
+	if err != nil {
+		logger.Error(
+			"unable to create external scan",
+			logger.Err(err),
+		)
+		return err
+	}
+
+	findings, err := runDASTInDocker(ctx, input, forcePullImage)
 	if err != nil {
 		return err
 	}
 
-	ctx := context.Background()
+	logger.Info(
+		"finished local scan",
+		logger.Int("findingsCount", len(findings)),
+	)
+
+	err = nullifyClient.DASTUpdateExternalScan(externalDASTScan.ScanID, &client.DASTUpdateExternalScanInput{
+		Findings: findings,
+	})
+	if err != nil {
+		logger.Error(
+			"unable to update external scan",
+			logger.Err(err),
+		)
+		return err
+	}
+
+	return nil
+}
+
+func runDASTInDocker(
+	ctx context.Context,
+	input *DASTExternalScanInput,
+	forcePullImage bool,
+) ([]models.DASTFinding, error) {
+	requestBody, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
 
 	dockerclient, err := docker.NewClientWithOpts(docker.FromEnv, docker.WithAPIVersionNegotiation())
 	if err != nil {
@@ -53,92 +96,164 @@ func StartLocalScan(nullifyClient *client.NullifyClient, input *StartLocalScanIn
 			"unable to create new docker client",
 			logger.Err(err),
 		)
-		return err
+		return nil, err
 	}
 	defer dockerclient.Close()
 
 	imageRef := fmt.Sprintf("ghcr.io/nullify-platform/dast-local:%s", input.Version)
 
-	pullOut, err := dockerclient.ImagePull(ctx, imageRef, types.ImagePullOptions{})
+	// check if image exists on local machine
+	imageExists := true
+	_, _, err = dockerclient.ImageInspectWithRaw(ctx, imageRef)
 	if err != nil {
-		logger.Error(
-			"unable to pull image from nullify platform ghrc",
-			logger.Err(err),
+		imageExists = false
+		logger.Info(
+			"unable to find image on local machine, pulling from nullify platform ghcr",
+			logger.String("imageRef", imageRef),
 		)
-		return err
-	}
-	defer pullOut.Close()
-
-	_, err = io.Copy(os.Stdout, pullOut)
-	if err != nil {
-		logger.Error(
-			"unable to copy image pull output to stdout",
-			logger.Err(err),
-		)
-		return err
 	}
 
-	containerResp, err := dockerclient.ContainerCreate(ctx, &container.Config{
-		Image: imageRef,
-		Cmd:   []string{string(requestBody)},
-	}, nil, nil, nil, "")
+	// pull image if it doesn't exist or forcePullImage is true
+	if !imageExists || forcePullImage {
+		pullOut, err := dockerclient.ImagePull(ctx, imageRef, types.ImagePullOptions{})
+		if err != nil {
+			logger.Error(
+				"unable to pull image from nullify platform ghrc",
+				logger.Err(err),
+			)
+			return nil, err
+		}
+		defer pullOut.Close()
+
+		_, err = io.Copy(os.Stdout, pullOut)
+		if err != nil {
+			logger.Error(
+				"unable to copy image pull output to stdout",
+				logger.Err(err),
+			)
+			return nil, err
+		}
+	}
+
+	containerResp, err := dockerclient.ContainerCreate(
+		ctx, &container.Config{
+			Image:        imageRef,
+			Tty:          true,
+			OpenStdin:    true,
+			AttachStdin:  true,
+			AttachStdout: true,
+			AttachStderr: true,
+		},
+		&container.HostConfig{
+			AutoRemove:  true,
+			NetworkMode: "host",
+		},
+		nil, nil, "",
+	)
 	if err != nil {
 		logger.Error(
 			"unable to create new docker container",
 			logger.Err(err),
 		)
-		return err
+		return nil, err
 	}
 
-	defer func() {
-		if err = dockerclient.ContainerRemove(ctx, containerResp.ID, container.RemoveOptions{RemoveVolumes: true, RemoveLinks: false, Force: true}); err != nil {
-			logger.Error(
-				"unable to remove container",
-				logger.Err(err),
-			)
-		}
-	}()
-
-	if err = dockerclient.ContainerStart(ctx, containerResp.ID, container.StartOptions{}); err != nil {
+	err = dockerclient.ContainerStart(ctx, containerResp.ID, container.StartOptions{})
+	if err != nil {
 		logger.Error(
 			"unable to start docker container",
 			logger.Err(err),
 		)
-		return err
+		return nil, err
 	}
 
-	statusCh, errCh := dockerclient.ContainerWait(ctx, containerResp.ID, container.WaitConditionNotRunning)
-	select {
-	case err := <-errCh:
-		if err != nil {
-			logger.Error(
-				"error while waiting for container to finish scan",
-				logger.Err(err),
-			)
-			return err
-		}
-	case <-statusCh:
+	hijackedResponse, err := dockerclient.ContainerAttach(ctx, containerResp.ID, container.AttachOptions{
+		Stderr: true,
+		Stdout: true,
+		Stdin:  true,
+		Stream: true,
+	})
+	if err != nil {
+		logger.Error(
+			"unable to attach to container",
+			logger.Err(err),
+		)
+		return nil, err
 	}
 
-	logsOut, err := dockerclient.ContainerLogs(ctx, containerResp.ID, container.LogsOptions{ShowStdout: true})
+	_, err = hijackedResponse.Conn.Write(append(requestBody, '\n'))
+	if err != nil {
+		logger.Error(
+			"unable to write request body to container",
+			logger.Err(err),
+		)
+		return nil, err
+	}
+
+	err = hijackedResponse.Conn.Close()
+	if err != nil {
+		logger.Error(
+			"unable to close connection to container",
+			logger.Err(err),
+		)
+		return nil, err
+	}
+
+	logsOut, err := dockerclient.ContainerLogs(ctx, containerResp.ID, container.LogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+	})
 	if err != nil {
 		logger.Error(
 			"unable to create docker container logs",
 			logger.Err(err),
 		)
-		return err
+		return nil, err
 	}
 
-	_, err = stdcopy.StdCopy(os.Stdout, os.Stderr, logsOut)
-	if err != nil {
+	defer logsOut.Close()
+
+	var lastLine string
+
+	scanner := bufio.NewScanner(logsOut)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 1024*1024)
+	for scanner.Scan() {
+		if lastLine != "" {
+			var output map[string]any
+			err = json.Unmarshal([]byte(lastLine), &output)
+			if err != nil {
+				fmt.Println(lastLine)
+			} else {
+				logger.Info(
+					"local scan progress",
+					logger.Any("progress", output),
+				)
+			}
+		}
+
+		lastLine = scanner.Text()
+	}
+
+	if err := scanner.Err(); err != nil {
 		logger.Error(
-			"unable to copy stdout from container to cli",
+			"error reading output from dast local container",
 			logger.Err(err),
 		)
-		return err
+		return nil, err
 	}
 
-	logger.Info("finished local scan")
+	// the last line before exiting is the findings
+	var output DASTExternalScanOutput
+	err = json.Unmarshal([]byte(lastLine), &output)
+	if err != nil {
+		logger.Error(
+			"unable to unmarshal findings from dast local container",
+			logger.Err(err),
+		)
+		return nil, err
+	}
 
-	return nil
+	return output.Findings, nil
 }


### PR DESCRIPTION
## Description

- use stdin / stdout interface for the dast image
- stream logs back from the dast image
- use new external scan api endpoints

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
