### PR TITLE
ignore first line of output

### DIFF
--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -39,7 +39,7 @@ func RunLocalScan(
 	logger.Info(
 		"starting local scan",
 		logger.String("appName", input.AppName),
-		logger.String("host", input.TargetHost),
+		logger.String("targetHost", input.TargetHost),
 	)
 
 	externalDASTScan, err := nullifyClient.DASTCreateExternalScan(githubOwner, &client.DASTCreateExternalScanInput{
@@ -243,6 +243,12 @@ func runDASTInDocker(
 	scanner := bufio.NewScanner(logsOut)
 	buf := make([]byte, maxBufferSize)
 	scanner.Buffer(buf, maxBufferSize)
+
+	if scanner.Scan() {
+		// ignore first line of logs as it is the request body
+		_ = scanner.Text()
+	}
+
 	for scanner.Scan() {
 		if lastLine != "" {
 			var output map[string]any


### PR DESCRIPTION
## Description

ignore first line for local dast container output as it echos the input

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
