### PR TITLE
improve container streaming

### DIFF
--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -154,8 +154,7 @@ func runDASTInDocker(
 
 	containerResp, err := dockerclient.ContainerCreate(
 		ctx, &container.Config{
-			Image: imageRef,
-			// Tty:          true,
+			Image:        imageRef,
 			OpenStdin:    true,
 			AttachStdin:  true,
 			AttachStdout: true,
@@ -182,17 +181,17 @@ func runDASTInDocker(
 		logger.Any("containerResp", containerResp),
 	)
 
-	// defer func() {
-	// 	err := dockerclient.ContainerRemove(ctx, containerResp.ID, container.RemoveOptions{
-	// 		Force: true,
-	// 	})
-	// 	if err != nil {
-	// 		logger.Error(
-	// 			"unable to remove docker container",
-	// 			logger.Err(err),
-	// 		)
-	// 	}
-	// }()
+	defer func() {
+		err := dockerclient.ContainerRemove(ctx, containerResp.ID, container.RemoveOptions{
+			Force: true,
+		})
+		if err != nil {
+			logger.Error(
+				"unable to remove docker container",
+				logger.Err(err),
+			)
+		}
+	}()
 
 	err = dockerclient.ContainerStart(ctx, containerResp.ID, container.StartOptions{})
 	if err != nil {

--- a/internal/dast/start_local_scan.go
+++ b/internal/dast/start_local_scan.go
@@ -252,7 +252,13 @@ func runDASTInDocker(
 		defer stdoutWriter.Close()
 		defer stderrWriter.Close()
 
-		stdcopy.StdCopy(stdoutWriter, stderrWriter, containerLogs.Reader)
+		_, err := stdcopy.StdCopy(stdoutWriter, stderrWriter, containerLogs.Reader)
+		if err != nil {
+			logger.Error(
+				"unable to copy container logs to stdout/stderr",
+				logger.Err(err),
+			)
+		}
 	}()
 
 	var lastLine string


### PR DESCRIPTION
## Description

remove the TTY from the container so that we can close the stdin independently of the stdout and stderr.

we also now have to handle the multiplexing of stdout and stderr.

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
