### PR TITLE
feat: support multiple headers for DAST scans (NUL-1187)

### DIFF
--- a/internal/lib/auth_headers.go
+++ b/internal/lib/auth_headers.go
@@ -11,16 +11,19 @@ func ParseAuthHeaders(authHeaders []string) (map[string]string, error) {
 	result := map[string]string{}
 
 	for _, header := range authHeaders {
-		headerParts := strings.Split(header, ": ")
-		if len(headerParts) != 2 {
-			err := fmt.Errorf("please provide headers in the format of 'key: value'")
-			logger.Err(err)
-			return nil, err
-		}
+		headers := strings.Split(header, ",")
+		for _, h := range headers {
+			headerParts := strings.Split(h, ": ")
+			if len(headerParts) != 2 {
+				err := fmt.Errorf("please provide headers in the format of 'key: value'")
+				logger.Err(err)
+				return nil, err
+			}
 
-		headerName := strings.TrimSpace(headerParts[0])
-		headerValue := strings.TrimSpace(headerParts[1])
-		result[headerName] = headerValue
+			headerName := strings.TrimSpace(headerParts[0])
+			headerValue := strings.TrimSpace(headerParts[1])
+			result[headerName] = headerValue
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
## Description

This PR refactors handling custom headers via CLI to support for a list of multiple headers separated by commas.

`./nullify dast --host <host> --header "Authorization: Bearer your-token,X-Custom-Header: custom-value`
```
2024-09-05T16:40:20.410+1000    INFO    dast/start_local_scan.go:344    local scan progress     {"version": "5494f306770ba28b5c8594dbd88e3d9cecf36bec-tainted", "progress": {"appName":"local-2024-09-05_16:40:19","authConfig":{"headers":{"Authorization":"Bearer your-token","X-Custom-Header":"custom-value"}},"caller":"dastlocal/main.go:49","level":"info","msg":"received local dast request","targetHost":"<host>","ts":1725518420.4108286,"version":"1.27.0"}}
```

## Linked Issues & PRs

- resolves <insert-issue-link>
- relates to <insert-pr-link>

[GitHub Issue Linking Docs](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)

## Checklist

- [ ] I have added one of the `patch`, `minor`, `major` or `no-release` labels
- [ ] I have linked an issue from this repository using the **Development** option
- [ ] I have performed a self-review of my own code
- [ ] I have checked for redundant or commented out code
- [ ] I have commented my code where I can't make it self-documenting
- [ ] I have made corresponding changes to the documentation
- [ ] I have added any appropriate tests
