### PR TITLE
fix: remove homebrew tap from goreleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -43,16 +43,6 @@ checksum:
 changelog:
   use: github-native
 
-brews:
-  - name: nullify
-    repository:
-      owner: Nullify-Platform
-      name: homebrew-tap
-    homepage: "https://github.com/Nullify-Platform/cli"
-    description: "Nullify CLI - autonomous AI workforce for product security"
-    install: |
-      bin.install "nullify"
-
 release:
   github:
     owner: Nullify-Platform


### PR DESCRIPTION
## Summary
- The `Release` workflow has been failing on every push to `main` because `.goreleaser.yaml` publishes a Homebrew formula to `Nullify-Platform/homebrew-tap`, which does not exist (404).
- The GitHub release itself (binaries, checksums, tag) is published successfully; only the post-release Homebrew step fails, so the workflow is marked red despite a working release.
- Removes the `brews:` block. Homebrew distribution can be re-introduced once the tap repo exists — a related branch (`feat/distribution-overhaul`) has already taken this direction.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm the next `Release` run on `main` completes without the `homebrew formula` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)