### PR TITLE
fix: disable scorecard publish and upload SARIF to code scanning

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,4 +29,9 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: false
+
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- The `OSSF Scorecard` workflow has failed every run for 2+ months. Root cause is upstream: `publish_results: true` POSTs to `api.scorecard.dev`, which returns HTTP 500 (with retries) after the analysis itself completes successfully. The action is already on the latest release (v2.4.3).
- Set `publish_results: false` to stop the failing publish call. This repo isn't relying on the public scorecard.dev badge.
- Add `github/codeql-action/upload-sarif` so the scorecard findings land in the GitHub Security tab — previously the SARIF file was generated but never uploaded anywhere, so the workflow produced no visible output even when it "passed".
- Action pinned by SHA (v3.35.2), consistent with the other pinned actions in this file.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, confirm the next `OSSF Scorecard` run on `main` completes successfully
- [ ] Confirm scorecard SARIF results appear under the repo's Security → Code scanning tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)