### PR TITLE
fix(auth): prefer newer credentials when migrating api. prefixed keys

### DIFF
--- a/cmd/cli/cmd/runtime_auth.go
+++ b/cmd/cli/cmd/runtime_auth.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"os"
 
 	"github.com/nullify-platform/cli/internal/auth"
 	"github.com/nullify-platform/cli/internal/lib"
@@ -28,6 +29,14 @@ func resolveCommandAuth(ctx context.Context) (*commandAuthContext, error) {
 			for key, value := range hostCreds.QueryParameters {
 				queryParams[key] = value
 			}
+		}
+	}
+
+	// NULLIFY_GITHUB_OWNER_ID env var provides the githubOwnerId query param
+	// when using NULLIFY_TOKEN directly (no stored credentials).
+	if ownerID := os.Getenv("NULLIFY_GITHUB_OWNER_ID"); ownerID != "" {
+		if _, set := queryParams["githubOwnerId"]; !set {
+			queryParams["githubOwnerId"] = ownerID
 		}
 	}
 

--- a/internal/auth/credentials.go
+++ b/internal/auth/credentials.go
@@ -49,7 +49,7 @@ func LoadCredentials() (Credentials, error) {
 	for k, v := range creds {
 		bare := strings.TrimPrefix(k, "api.")
 		if bare != k {
-			if _, exists := creds[bare]; !exists {
+			if existing, exists := creds[bare]; !exists || v.ExpiresAt > existing.ExpiresAt {
 				creds[bare] = v
 			}
 			delete(creds, k)


### PR DESCRIPTION
## Summary

- When migrating credentials stored under the old `api.<host>` key format to the bare `<host>` format, the migration unconditionally kept the existing bare key if it already existed — silently discarding the freshly-saved credentials from the new login
- Fix: prefer whichever entry has the later `ExpiresAt`, so a fresh login always wins over a stale one

## Root cause

Users upgrading from an older binary (which saved credentials under `api.<host>`) would:
1. Log in successfully → new credentials saved under `api.<host>`
2. Run the updated binary → migration runs, sees `<host>` already exists (old expired token), deletes `api.<host>` without migrating
3. End up with only the old expired credentials, stuck in an auth loop

## Test plan
- [ ] Log in with an older binary (saves under `api.<host>`)
- [ ] Run updated binary — credentials should reflect the newer token, not the old one