### PR TITLE
feat(cli): add first-class scan, sbom, and threat commands

### DIFF
--- a/cmd/cli/cmd/sbom.go
+++ b/cmd/cli/cmd/sbom.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+
+	"github.com/nullify-platform/cli/internal/logger"
+	"github.com/nullify-platform/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var sbomCmd = &cobra.Command{
+	Use:   "sbom",
+	Short: "Retrieve software bill of materials (SBOM) data",
+	Long:  "Retrieve SBOM data for a repository. Returns the latest SBOM by default, or a specific project's SBOM when --project-id is provided.",
+}
+
+var sbomGetCmd = &cobra.Command{
+	Use:   "get",
+	Short: "Get the SBOM for a repository",
+	Example: "  nullify sbom get --repository-id repo-123\n" +
+		"  nullify sbom get --repository-id repo-123 --project-id proj-456",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		repositoryID, _ := cmd.Flags().GetString("repository-id")
+		projectID, _ := cmd.Flags().GetString("project-id")
+
+		params := url.Values{}
+		params.Set("repositoryId", repositoryID)
+
+		apiClient := getAPIClient()
+
+		var result []byte
+		var err error
+		if projectID != "" {
+			params.Set("projectId", projectID)
+			result, err = apiClient.GetContextSbomsRepositoryRepositoryIdProjectProjectId(ctx, params)
+		} else {
+			result, err = apiClient.ListContextSbomsRepositoryRepositoryIdLatest(ctx, params)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(sbomCmd)
+	sbomCmd.AddCommand(sbomGetCmd)
+
+	sbomGetCmd.Flags().String("repository-id", "", "Repository ID to retrieve the SBOM for")
+	sbomGetCmd.Flags().String("project-id", "", "Project ID for a specific project SBOM (latest repository SBOM if omitted)")
+	_ = sbomGetCmd.MarkFlagRequired("repository-id")
+}

--- a/cmd/cli/cmd/sbom.go
+++ b/cmd/cli/cmd/sbom.go
@@ -1,10 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 
+	"github.com/nullify-platform/cli/internal/api"
 	"github.com/nullify-platform/cli/internal/logger"
 	"github.com/nullify-platform/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -28,26 +29,32 @@ var sbomGetCmd = &cobra.Command{
 		repositoryID, _ := cmd.Flags().GetString("repository-id")
 		projectID, _ := cmd.Flags().GetString("project-id")
 
-		params := url.Values{}
-		params.Set("repositoryId", repositoryID)
-
 		apiClient := getAPIClient()
 
-		var result []byte
+		var result any
 		var err error
 		if projectID != "" {
-			params.Set("projectId", projectID)
-			result, err = apiClient.GetContextSbomsRepositoryRepositoryIdProjectProjectId(ctx, params)
+			result, err = apiClient.GetContextSbomsRepositoryRepositoryIdProjectProjectId(ctx, api.GetContextSbomsRepositoryRepositoryIdProjectProjectIdInput{
+				RepositoryID: repositoryID,
+				ProjectID:    projectID,
+			})
 		} else {
-			result, err = apiClient.ListContextSbomsRepositoryRepositoryIdLatest(ctx, params)
+			result, err = apiClient.ListContextSbomsRepositoryRepositoryIdLatest(ctx, api.ListContextSbomsRepositoryRepositoryIdLatestInput{
+				RepositoryID: repositoryID,
+			})
 		}
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }

--- a/cmd/cli/cmd/scan.go
+++ b/cmd/cli/cmd/scan.go
@@ -1,11 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
-	"strconv"
 
+	"github.com/nullify-platform/cli/internal/api"
 	"github.com/nullify-platform/cli/internal/logger"
 	"github.com/nullify-platform/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -27,14 +27,19 @@ var scanStartCmd = &cobra.Command{
 
 		apiClient := getAPIClient()
 
-		result, err := apiClient.CreateContextCloudScanStart(ctx, url.Values{})
+		result, err := apiClient.CreateContextCloudScanStart(ctx, api.CreateContextCloudScanStartInput{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }
@@ -50,17 +55,21 @@ var scanStatusCmd = &cobra.Command{
 
 		apiClient := getAPIClient()
 
-		params := url.Values{}
-		params.Set("scanId", args[0])
-
-		result, err := apiClient.ListContextCloudScanScanIdStatus(ctx, params)
+		result, err := apiClient.ListContextCloudScanScanIdStatus(ctx, api.ListContextCloudScanScanIdStatusInput{
+			ScanID: args[0],
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }
@@ -79,23 +88,35 @@ var scanRunsCmd = &cobra.Command{
 		repositoryID, _ := cmd.Flags().GetString("repository-id")
 		limit, _ := cmd.Flags().GetInt("limit")
 
-		params := url.Values{}
-		params.Set("repositoryId", repositoryID)
-		if limit > 0 {
-			params.Set("limit", strconv.Itoa(limit))
-		}
-
 		apiClient := getAPIClient()
 
-		var result []byte
-		var err error
+		var (
+			result any
+			err    error
+		)
+
+		repoPtr := &repositoryID
+		var limitPtr *int
+		if limit > 0 {
+			limitPtr = &limit
+		}
+
 		switch scanType {
 		case "sast":
-			result, err = apiClient.ListSastScanRuns(ctx, params)
+			result, err = apiClient.ListSastScanRuns(ctx, api.ListSastScanRunsInput{
+				RepositoryID: repoPtr,
+				Limit:        limitPtr,
+			})
 		case "sca":
-			result, err = apiClient.ListScaScanRuns(ctx, params)
+			result, err = apiClient.ListScaScanRuns(ctx, api.ListScaScanRunsInput{
+				RepositoryID: repoPtr,
+				Limit:        limitPtr,
+			})
 		case "secrets":
-			result, err = apiClient.ListSecretsScanRuns(ctx, params)
+			result, err = apiClient.ListSecretsScanRuns(ctx, api.ListSecretsScanRunsInput{
+				RepositoryID: repoPtr,
+				Limit:        limitPtr,
+			})
 		default:
 			fmt.Fprintf(os.Stderr, "Error: invalid --type %q (must be one of: sast, sca, secrets)\n", scanType)
 			os.Exit(1)
@@ -105,8 +126,13 @@ var scanRunsCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }

--- a/cmd/cli/cmd/scan.go
+++ b/cmd/cli/cmd/scan.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"strconv"
+
+	"github.com/nullify-platform/cli/internal/logger"
+	"github.com/nullify-platform/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var scanCmd = &cobra.Command{
+	Use:   "scan",
+	Short: "Start cloud scans and inspect scan runs",
+	Long:  "Start a cloud scan, check the status of a running scan, and list historical scan runs per scanner type.",
+}
+
+var scanStartCmd = &cobra.Command{
+	Use:     "start",
+	Short:   "Start a cloud scan",
+	Example: "  nullify scan start",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		apiClient := getAPIClient()
+
+		result, err := apiClient.CreateContextCloudScanStart(ctx, url.Values{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+var scanStatusCmd = &cobra.Command{
+	Use:     "status <scanId>",
+	Short:   "Get the status of a cloud scan",
+	Args:    cobra.ExactArgs(1),
+	Example: "  nullify scan status abc123",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		apiClient := getAPIClient()
+
+		params := url.Values{}
+		params.Set("scanId", args[0])
+
+		result, err := apiClient.ListContextCloudScanScanIdStatus(ctx, params)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+var scanRunsCmd = &cobra.Command{
+	Use:   "runs",
+	Short: "List scan runs for a scanner type",
+	Long:  "List historical scan runs for a repository. Use --type to select the scanner (sast, sca, or secrets).",
+	Example: "  nullify scan runs --type sast --repository-id repo-123\n" +
+		"  nullify scan runs --type sca --repository-id repo-123 --limit 10",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		scanType, _ := cmd.Flags().GetString("type")
+		repositoryID, _ := cmd.Flags().GetString("repository-id")
+		limit, _ := cmd.Flags().GetInt("limit")
+
+		params := url.Values{}
+		params.Set("repositoryId", repositoryID)
+		if limit > 0 {
+			params.Set("limit", strconv.Itoa(limit))
+		}
+
+		apiClient := getAPIClient()
+
+		var result []byte
+		var err error
+		switch scanType {
+		case "sast":
+			result, err = apiClient.ListSastScanRuns(ctx, params)
+		case "sca":
+			result, err = apiClient.ListScaScanRuns(ctx, params)
+		case "secrets":
+			result, err = apiClient.ListSecretsScanRuns(ctx, params)
+		default:
+			fmt.Fprintf(os.Stderr, "Error: invalid --type %q (must be one of: sast, sca, secrets)\n", scanType)
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(scanCmd)
+	scanCmd.AddCommand(scanStartCmd)
+	scanCmd.AddCommand(scanStatusCmd)
+	scanCmd.AddCommand(scanRunsCmd)
+
+	scanRunsCmd.Flags().String("type", "", "Scanner type (sast, sca, secrets)")
+	scanRunsCmd.Flags().String("repository-id", "", "Repository ID to list scan runs for")
+	scanRunsCmd.Flags().Int("limit", 0, "Maximum number of scan runs to return")
+	_ = scanRunsCmd.MarkFlagRequired("type")
+	_ = scanRunsCmd.MarkFlagRequired("repository-id")
+}

--- a/cmd/cli/cmd/threat.go
+++ b/cmd/cli/cmd/threat.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/nullify-platform/cli/internal/logger"
+	"github.com/nullify-platform/cli/internal/output"
+	"github.com/spf13/cobra"
+)
+
+var threatCmd = &cobra.Command{
+	Use:   "threat",
+	Short: "Manage threat investigations",
+	Long:  "List, inspect, and create threat investigations.",
+}
+
+var threatListCmd = &cobra.Command{
+	Use:     "list",
+	Short:   "List threat investigations",
+	Example: "  nullify threat list",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		apiClient := getAPIClient()
+
+		result, err := apiClient.ListManagerThreatInvestigations(ctx, url.Values{})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+var threatGetCmd = &cobra.Command{
+	Use:     "get <id>",
+	Short:   "Get a threat investigation by ID",
+	Args:    cobra.ExactArgs(1),
+	Example: "  nullify threat get ti-123",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		apiClient := getAPIClient()
+
+		params := url.Values{}
+		params.Set("threatInvestigationId", args[0])
+
+		result, err := apiClient.GetManagerThreatInvestigationsThreatInvestigationId(ctx, params)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+var threatCreateCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create a threat investigation",
+	Example: "  nullify threat create --title \"Log4Shell\" --severity critical\n" +
+		"  nullify threat create --title \"CVE sweep\" --cve-ids CVE-2021-44228,CVE-2021-45046",
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx := setupLogger(cmd.Context())
+		defer logger.Close(ctx)
+
+		title, _ := cmd.Flags().GetString("title")
+		description, _ := cmd.Flags().GetString("description")
+		severity, _ := cmd.Flags().GetString("severity")
+		advice, _ := cmd.Flags().GetString("advice")
+		ecosystem, _ := cmd.Flags().GetString("ecosystem")
+		keywords, _ := cmd.Flags().GetString("keywords")
+		cvss, _ := cmd.Flags().GetString("cvss")
+		cveIDs, _ := cmd.Flags().GetString("cve-ids")
+		articleLinks, _ := cmd.Flags().GetString("article-links")
+
+		body := map[string]any{
+			"title": title,
+		}
+		if description != "" {
+			body["description"] = description
+		}
+		if severity != "" {
+			body["severity"] = severity
+		}
+		if advice != "" {
+			body["advice"] = advice
+		}
+		if ecosystem != "" {
+			body["ecosystem"] = ecosystem
+		}
+		if keywords != "" {
+			body["keywords"] = keywords
+		}
+		if cvss != "" {
+			body["cvss"] = cvss
+		}
+		if cveIDs != "" {
+			body["cveIds"] = splitCSV(cveIDs)
+		}
+		if articleLinks != "" {
+			body["articleLinks"] = splitCSV(articleLinks)
+		}
+
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		apiClient := getAPIClient()
+
+		result, err := apiClient.CreateManagerThreatInvestigations(ctx, url.Values{}, bytes.NewReader(bodyBytes))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+
+		if err := output.Print(cmd, result); err != nil {
+			fmt.Fprintln(os.Stderr, string(result))
+		}
+	},
+}
+
+func splitCSV(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+	return out
+}
+
+func init() {
+	rootCmd.AddCommand(threatCmd)
+	threatCmd.AddCommand(threatListCmd)
+	threatCmd.AddCommand(threatGetCmd)
+	threatCmd.AddCommand(threatCreateCmd)
+
+	threatCreateCmd.Flags().String("title", "", "Title of the threat investigation (required)")
+	threatCreateCmd.Flags().String("description", "", "Description of the threat")
+	threatCreateCmd.Flags().String("severity", "", "Severity of the threat")
+	threatCreateCmd.Flags().String("advice", "", "Remediation advice")
+	threatCreateCmd.Flags().String("ecosystem", "", "Affected ecosystem")
+	threatCreateCmd.Flags().String("keywords", "", "Search keywords")
+	threatCreateCmd.Flags().String("cvss", "", "CVSS score")
+	threatCreateCmd.Flags().String("cve-ids", "", "Comma-separated list of CVE IDs")
+	threatCreateCmd.Flags().String("article-links", "", "Comma-separated list of article links")
+	_ = threatCreateCmd.MarkFlagRequired("title")
+}

--- a/cmd/cli/cmd/threat.go
+++ b/cmd/cli/cmd/threat.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
+	"github.com/nullify-platform/cli/internal/api"
 	"github.com/nullify-platform/cli/internal/logger"
 	"github.com/nullify-platform/cli/internal/output"
 	"github.com/spf13/cobra"
@@ -29,14 +29,19 @@ var threatListCmd = &cobra.Command{
 
 		apiClient := getAPIClient()
 
-		result, err := apiClient.ListManagerThreatInvestigations(ctx, url.Values{})
+		result, err := apiClient.ListManagerThreatInvestigations(ctx, api.ListManagerThreatInvestigationsInput{})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }
@@ -52,17 +57,21 @@ var threatGetCmd = &cobra.Command{
 
 		apiClient := getAPIClient()
 
-		params := url.Values{}
-		params.Set("threatInvestigationId", args[0])
-
-		result, err := apiClient.GetManagerThreatInvestigationsThreatInvestigationId(ctx, params)
+		result, err := apiClient.GetManagerThreatInvestigationsThreatInvestigationId(ctx, api.GetManagerThreatInvestigationsThreatInvestigationIdInput{
+			ThreatInvestigationID: args[0],
+		})
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }
@@ -86,50 +95,54 @@ var threatCreateCmd = &cobra.Command{
 		cveIDs, _ := cmd.Flags().GetString("cve-ids")
 		articleLinks, _ := cmd.Flags().GetString("article-links")
 
-		body := map[string]any{
-			"title": title,
+		in := api.CreateManagerThreatInvestigationsInput{
+			Title: title,
 		}
 		if description != "" {
-			body["description"] = description
+			in.Description = &description
 		}
 		if severity != "" {
-			body["severity"] = severity
+			in.Severity = &severity
 		}
 		if advice != "" {
-			body["advice"] = advice
+			in.Advice = &advice
 		}
 		if ecosystem != "" {
-			body["ecosystem"] = ecosystem
+			in.Ecosystem = &ecosystem
 		}
 		if keywords != "" {
-			body["keywords"] = keywords
+			in.Keywords = &keywords
 		}
 		if cvss != "" {
-			body["cvss"] = cvss
+			cvssFloat, err := strconv.ParseFloat(cvss, 64)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: invalid --cvss %q: %v\n", cvss, err)
+				os.Exit(1)
+			}
+			in.Cvss = &cvssFloat
 		}
 		if cveIDs != "" {
-			body["cveIds"] = splitCSV(cveIDs)
+			in.CveIds = splitCSV(cveIDs)
 		}
 		if articleLinks != "" {
-			body["articleLinks"] = splitCSV(articleLinks)
-		}
-
-		bodyBytes, err := json.Marshal(body)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
-			os.Exit(1)
+			in.ArticleLinks = splitCSV(articleLinks)
 		}
 
 		apiClient := getAPIClient()
 
-		result, err := apiClient.CreateManagerThreatInvestigations(ctx, url.Values{}, bytes.NewReader(bodyBytes))
+		result, err := apiClient.CreateManagerThreatInvestigations(ctx, in)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)
 		}
 
-		if err := output.Print(cmd, result); err != nil {
-			fmt.Fprintln(os.Stderr, string(result))
+		data, err := json.Marshal(result)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		if err := output.Print(cmd, data); err != nil {
+			fmt.Fprintln(os.Stderr, string(data))
 		}
 	},
 }


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

Adds first-class top-level commands `scan`, `sbom`, and `threat` that mirror the MCP tools, so humans and AI agents discover them directly from top-level `--help` instead of digging through `nullify api <svc> <verb>-<noun>`.

## Commands

- `nullify scan start` — start a cloud scan
- `nullify scan status <scanId>` — get the status of a cloud scan
- `nullify scan runs --type sast|sca|secrets --repository-id <id> [--limit N]` — list scan runs per scanner type
- `nullify sbom get --repository-id <id> [--project-id <id>]` — latest repository SBOM, or a specific project's SBOM
- `nullify threat list` — list threat investigations
- `nullify threat get <id>` — get a threat investigation by ID
- `nullify threat create --title <t> [--description --severity --advice --ecosystem --keywords --cvss --cve-ids --article-links]` — create a threat investigation (`--cve-ids` / `--article-links` are comma-separated → JSON arrays)

## Implementation notes

- Hand-written cobra commands in `cmd/cli/cmd/scan.go`, `sbom.go`, `threat.go`, self-registering via `init()` against `rootCmd` (same pattern as `findings.go` / `repos.go`).
- Clients resolved through the existing package-level `getAPIClient`; output via `internal/output`.
- Path-param args use `cobra.ExactArgs(1)`; flags are kebab-case.

## Testing

- `GOWORK=off CGO_ENABLED=0 go build ./...` ✅
- `GOWORK=off go vet ./...` ✅
- `GOWORK=off go test ./...` ✅
- Smoke-tested `scan --help`, `sbom --help`, `threat --help` and confirmed all three appear in top-level `--help`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)