### PR TITLE
refactor(cli): type severity, auth method, and scan status enums

### DIFF
--- a/internal/client/dast.go
+++ b/internal/client/dast.go
@@ -1,5 +1,46 @@
 package client
 
+import "fmt"
+
+// ScanStatus is a string-based enum describing the status of a DAST external
+// scan.
+//
+// It is a named string type so it marshals/unmarshals to and from JSON as the
+// same lowercase strings used on the wire, with no custom (Un)MarshalJSON
+// required.
+type ScanStatus string
+
 const (
-	StatusCompleted = "completed"
+	StatusCompleted ScanStatus = "completed"
 )
+
+// String returns the underlying wire string for the scan status.
+func (s ScanStatus) String() string {
+	return string(s)
+}
+
+// IsValid reports whether the scan status is one of the known values.
+func (s ScanStatus) IsValid() bool {
+	switch s {
+	case StatusCompleted:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseScanStatus converts a raw string into a ScanStatus, rejecting unknown
+// values. Use it at trust boundaries where input must be validated.
+func ParseScanStatus(s string) (ScanStatus, error) {
+	status := ScanStatus(s)
+	if !status.IsValid() {
+		return "", fmt.Errorf("invalid scan status %q", s)
+	}
+	return status, nil
+}
+
+// ScanStatusPtr returns a pointer to the given scan status, mirroring the
+// String/Int pointer helpers used for optional request fields.
+func ScanStatusPtr(value ScanStatus) *ScanStatus {
+	return &value
+}

--- a/internal/client/dast_external_scan_create.go
+++ b/internal/client/dast_external_scan_create.go
@@ -12,10 +12,10 @@ import (
 type DASTCreateExternalScanInput struct {
 	AppName string `json:"appName"`
 
-	Progress  *int       `json:"progress"`
-	Status    *string    `json:"status"`
-	StartTime *time.Time `json:"startTime"`
-	EndTime   *time.Time `json:"endTime"`
+	Progress  *int        `json:"progress"`
+	Status    *ScanStatus `json:"status"`
+	StartTime *time.Time  `json:"startTime"`
+	EndTime   *time.Time  `json:"endTime"`
 
 	models.RequestProvider
 	models.RequestDashboardTarget

--- a/internal/client/dast_external_scan_update.go
+++ b/internal/client/dast_external_scan_update.go
@@ -11,7 +11,7 @@ import (
 
 type DASTUpdateExternalScanInput struct {
 	Progress *int                 `json:"progress"`
-	Status   *string              `json:"status"`
+	Status   *ScanStatus          `json:"status"`
 	Findings []models.DASTFinding `json:"findings"`
 
 	*models.RequestDashboardTarget

--- a/internal/client/dast_test.go
+++ b/internal/client/dast_test.go
@@ -1,0 +1,33 @@
+package client
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanStatusJSONRoundTrip(t *testing.T) {
+	// The wire representation must remain the same lowercase string after the
+	// Status field was changed from *string to the typed *ScanStatus enum.
+	input := DASTUpdateExternalScanInput{
+		Status: ScanStatusPtr(StatusCompleted),
+	}
+
+	out, err := json.Marshal(input)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Equal(t, "completed", got["status"])
+}
+
+func TestParseScanStatus(t *testing.T) {
+	s, err := ParseScanStatus("completed")
+	require.NoError(t, err)
+	require.Equal(t, StatusCompleted, s)
+	require.Equal(t, "completed", s.String())
+
+	_, err = ParseScanStatus("pending")
+	require.Error(t, err)
+}

--- a/internal/models/auth.go
+++ b/internal/models/auth.go
@@ -3,7 +3,7 @@ package models
 // AuthConfig represents the authentication configuration for Nullify DAST
 type AuthConfig struct {
 	// Single user authentication fields
-	Method          string                 `json:"method,omitempty"`
+	Method          AuthMethod             `json:"method,omitempty"`
 	Username        string                 `json:"username,omitempty"`
 	UserDescription string                 `json:"userDescription,omitempty"`
 	Headers         map[string]string      `json:"headers,omitempty"`
@@ -32,7 +32,7 @@ type UserAuth struct {
 }
 
 type MultiUserAuthConfig struct {
-	Method        string                 `json:"method,omitempty"`
+	Method        AuthMethod             `json:"method,omitempty"`
 	Username      string                 `json:"username,omitempty"`
 	Password      string                 `json:"password,omitempty"`
 	Token         string                 `json:"token,omitempty"`

--- a/internal/models/auth_method.go
+++ b/internal/models/auth_method.go
@@ -1,0 +1,48 @@
+package models
+
+import "fmt"
+
+// AuthMethod is a string-based enum describing the authentication method used
+// by a DAST scan's AuthConfig.
+//
+// It is a named string type so it marshals/unmarshals to and from JSON as the
+// same strings used on the wire, with no custom (Un)MarshalJSON required. The
+// concrete set of methods is owned by the DAST scanner that consumes the auth
+// config; the constants below cover the commonly documented methods. Unknown
+// values still unmarshal fine — validation only happens where ParseAuthMethod
+// is explicitly called at a trust boundary.
+type AuthMethod string
+
+const (
+	AuthMethodBasic  AuthMethod = "basic"
+	AuthMethodBearer AuthMethod = "bearer"
+	AuthMethodOAuth  AuthMethod = "oauth"
+	AuthMethodForm   AuthMethod = "form"
+	AuthMethodHeader AuthMethod = "header"
+	AuthMethodCookie AuthMethod = "cookie"
+)
+
+// String returns the underlying wire string for the auth method.
+func (m AuthMethod) String() string {
+	return string(m)
+}
+
+// IsValid reports whether the auth method is one of the known values.
+func (m AuthMethod) IsValid() bool {
+	switch m {
+	case AuthMethodBasic, AuthMethodBearer, AuthMethodOAuth, AuthMethodForm, AuthMethodHeader, AuthMethodCookie:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseAuthMethod converts a raw string into an AuthMethod, rejecting unknown
+// values. Use it at trust boundaries where input must be validated.
+func ParseAuthMethod(s string) (AuthMethod, error) {
+	m := AuthMethod(s)
+	if !m.IsValid() {
+		return "", fmt.Errorf("invalid auth method %q", s)
+	}
+	return m, nil
+}

--- a/internal/models/findings.go
+++ b/internal/models/findings.go
@@ -54,13 +54,13 @@ type Tags struct {
 }
 
 type DASTFinding struct {
-	ID       string `json:"id"`
-	Scanner  string `json:"scanner"`
-	Title    string `json:"title"`
-	Severity string `json:"severity"`
-	AppType  string `json:"appType"`
-	CWE      string `json:"cwe"`
-	Solution string `json:"solution"`
+	ID       string   `json:"id"`
+	Scanner  string   `json:"scanner"`
+	Title    string   `json:"title"`
+	Severity Severity `json:"severity"`
+	AppType  string   `json:"appType"`
+	CWE      string   `json:"cwe"`
+	Solution string   `json:"solution"`
 	Tags     []Tags
 	REST     RESTFinding `json:"rest"`
 }

--- a/internal/models/severity.go
+++ b/internal/models/severity.go
@@ -1,0 +1,43 @@
+package models
+
+import "fmt"
+
+// Severity is a string-based enum describing the severity of a finding.
+//
+// It is a named string type so it marshals/unmarshals to and from JSON as the
+// same lowercase strings used on the wire, with no custom (Un)MarshalJSON
+// required.
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityHigh     Severity = "high"
+	SeverityMedium   Severity = "medium"
+	SeverityLow      Severity = "low"
+	SeverityInfo     Severity = "info"
+)
+
+// String returns the underlying wire string for the severity.
+func (s Severity) String() string {
+	return string(s)
+}
+
+// IsValid reports whether the severity is one of the known values.
+func (s Severity) IsValid() bool {
+	switch s {
+	case SeverityCritical, SeverityHigh, SeverityMedium, SeverityLow, SeverityInfo:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseSeverity converts a raw string into a Severity, rejecting unknown
+// values. Use it at trust boundaries where input must be validated.
+func ParseSeverity(s string) (Severity, error) {
+	sev := Severity(s)
+	if !sev.IsValid() {
+		return "", fmt.Errorf("invalid severity %q", s)
+	}
+	return sev, nil
+}

--- a/internal/models/severity_test.go
+++ b/internal/models/severity_test.go
@@ -1,0 +1,68 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDASTFindingSeverityJSONRoundTrip(t *testing.T) {
+	// The wire representation must remain the same lowercase strings as before
+	// the field was changed from string to the typed Severity enum.
+	raw := `{"id":"f1","scanner":"dast","title":"SQLi","severity":"critical","appType":"rest","cwe":"CWE-89","solution":"fix it","rest":{}}`
+
+	var finding DASTFinding
+	require.NoError(t, json.Unmarshal([]byte(raw), &finding))
+	require.Equal(t, SeverityCritical, finding.Severity)
+
+	out, err := json.Marshal(finding)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Equal(t, "critical", got["severity"])
+}
+
+func TestSeverityIsValid(t *testing.T) {
+	require.True(t, SeverityCritical.IsValid())
+	require.True(t, SeverityHigh.IsValid())
+	require.True(t, SeverityMedium.IsValid())
+	require.True(t, SeverityLow.IsValid())
+	require.True(t, SeverityInfo.IsValid())
+	require.False(t, Severity("bogus").IsValid())
+}
+
+func TestParseSeverity(t *testing.T) {
+	sev, err := ParseSeverity("high")
+	require.NoError(t, err)
+	require.Equal(t, SeverityHigh, sev)
+	require.Equal(t, "high", sev.String())
+
+	_, err = ParseSeverity("nope")
+	require.Error(t, err)
+}
+
+func TestAuthMethodJSONRoundTrip(t *testing.T) {
+	raw := `{"method":"basic","username":"u"}`
+
+	var cfg AuthConfig
+	require.NoError(t, json.Unmarshal([]byte(raw), &cfg))
+	require.Equal(t, AuthMethodBasic, cfg.Method)
+
+	out, err := json.Marshal(cfg)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(out, &got))
+	require.Equal(t, "basic", got["method"])
+}
+
+func TestParseAuthMethod(t *testing.T) {
+	m, err := ParseAuthMethod("oauth")
+	require.NoError(t, err)
+	require.Equal(t, AuthMethodOAuth, m)
+
+	_, err = ParseAuthMethod("telepathy")
+	require.Error(t, err)
+}

--- a/internal/pentest/local_scan.go
+++ b/internal/pentest/local_scan.go
@@ -70,7 +70,7 @@ func RunLocalScan(
 
 	err = nullifyClient.DASTUpdateExternalScan(ctx, githubOwner, githubRepository, externalScan.ScanID, &client.DASTUpdateExternalScanInput{
 		Progress: client.Int(100),
-		Status:   client.String(client.StatusCompleted),
+		Status:   client.ScanStatusPtr(client.StatusCompleted),
 		Findings: findings,
 	})
 	if err != nil {


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## What

Replaces stringly-typed fields in `internal/models` and the lone DAST scan-status const in `internal/client/dast.go` with named string-based enums, following the repo convention of typed enums over magic strings. JSON wire compatibility is fully preserved — named string types marshal/unmarshal to the same strings as before.

## Changes

- **`models.Severity`** (`critical`/`high`/`medium`/`low`/`info`) with `IsValid()`, `String()`, and `ParseSeverity()` for boundary validation. `DASTFinding.Severity` is now this type.
- **`models.AuthMethod`** (`basic`/`bearer`/`oauth`/`form`/`header`/`cookie`) with `IsValid()`, `String()`, and `ParseAuthMethod()`. `AuthConfig.Method` and `MultiUserAuthConfig.Method` are now this type. Unknown values still unmarshal fine; validation only happens where `ParseAuthMethod` is explicitly called, so existing config files keep working.
- **`client.ScanStatus`** (`completed`) with `IsValid()`, `String()`, `ParseScanStatus()`, and a `ScanStatusPtr()` pointer helper. The `Status` fields of the DAST external-scan create/update inputs are now `*ScanStatus`, and the local-scan call site uses the typed constant — no `string()` casts in business logic.

## Notes

- `internal/output/sarif.go` parses severity from untyped JSON maps (`f["severity"].(string)`), not the typed `DASTFinding.Severity` field, so it is intentionally left unchanged — there is no typed value to route through it and no `string()` cast involved.
- The `AuthMethod` valid set is owned by the downstream DAST scanner and isn't referenced in CLI code; the constants cover the commonly documented methods, and unmarshaling is never gated, so no valid config can break.

## Testing

- `GOWORK=off CGO_ENABLED=0 go build ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test ./...`
- Added JSON round-trip and parse unit tests confirming the wire strings (`severity`, `method`, `status`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)