### PR TITLE
fix(output): handle findings object + locations/rules in SARIF, wire into ci

### DIFF
--- a/cmd/cli/cmd/ci.go
+++ b/cmd/cli/cmd/ci.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nullify-platform/cli/internal/client"
 	"github.com/nullify-platform/cli/internal/lib"
 	"github.com/nullify-platform/cli/internal/logger"
+	"github.com/nullify-platform/cli/internal/output"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -100,7 +101,6 @@ Exit codes:
 
 		var totalFindings int64
 		var apiErrors int64
-		totalRequests := int64(len(endpoints) * len(severities))
 		var mu sync.Mutex
 		g, gctx := errgroup.WithContext(ctx)
 
@@ -123,7 +123,10 @@ Exit codes:
 						return nil
 					}
 
-					count := countFindings(body)
+					// limit=1 keeps the payload small; the accurate count
+					// comes from the response's "total" field, not the
+					// truncated items array.
+					count := totalFindingsCount(body)
 					if count > 0 {
 						atomic.AddInt64(&totalFindings, int64(count))
 						mu.Lock()
@@ -137,8 +140,10 @@ Exit codes:
 
 		_ = g.Wait()
 
-		if apiErrors > 0 && apiErrors == totalRequests {
-			fmt.Fprintf(os.Stderr, "Error: all API requests failed, cannot determine gate status\n")
+		// Fail-closed: any scanner request error means we cannot prove the
+		// gate is clean, so treat it as a failure rather than passing.
+		if apiErrors > 0 {
+			fmt.Fprintf(os.Stderr, "Error: %d scanner request(s) failed; failing the gate (cannot confirm a clean result)\n", apiErrors)
 			os.Exit(ExitNetworkError)
 		}
 
@@ -153,10 +158,13 @@ Exit codes:
 
 var ciReportCmd = &cobra.Command{
 	Use:   "report",
-	Short: "Generate a markdown summary for PR comments",
-	Long:  "Output a markdown summary of security findings suitable for PR comments. Shows counts by type and severity.",
+	Short: "Generate a findings report (markdown or SARIF)",
+	Long: `Output a report of security findings. The default markdown format produces a
+summary table suitable for PR comments (counts by type and severity). The sarif
+format emits a SARIF v2.1.0 document for upload to code-scanning tools.`,
 	Example: `  nullify ci report
-  nullify ci report --repo my-org/my-repo`,
+  nullify ci report --repo my-org/my-repo
+  nullify ci report --format sarif > nullify.sarif`,
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := setupLogger(cmd.Context())
 		defer logger.Close(ctx)
@@ -187,6 +195,14 @@ var ciReportCmd = &cobra.Command{
 			repo = lib.DetectRepoFromGit()
 		}
 
+		format, _ := cmd.Flags().GetString("format")
+		switch format {
+		case "markdown", "sarif":
+		default:
+			fmt.Fprintf(os.Stderr, "Error: invalid --format %q. Valid values: markdown, sarif\n", format)
+			os.Exit(1)
+		}
+
 		endpoints := allScannerEndpoints()
 		severities := []string{"critical", "high", "medium", "low"}
 
@@ -194,6 +210,7 @@ var ciReportCmd = &cobra.Command{
 			scanner  string
 			severity string
 			count    int
+			findings []json.RawMessage
 		}
 
 		rows := make([]reportRow, len(endpoints)*len(severities))
@@ -225,7 +242,8 @@ var ciReportCmd = &cobra.Command{
 					rows[i*len(severities)+j] = reportRow{
 						scanner:  ep.name,
 						severity: sev,
-						count:    countFindings(body),
+						count:    totalFindingsCount(body),
+						findings: extractFindings(body),
 					}
 					return nil
 				})
@@ -240,6 +258,21 @@ var ciReportCmd = &cobra.Command{
 		}
 		if apiErrors > 0 {
 			fmt.Fprintf(os.Stderr, "Warning: %d API requests failed while generating the report\n", apiErrors)
+		}
+
+		if format == "sarif" {
+			all := make([]json.RawMessage, 0)
+			for _, row := range rows {
+				all = append(all, row.findings...)
+			}
+			wrapped, _ := json.Marshal(map[string]any{"findings": all, "total": len(all)})
+			sarifBytes, err := output.SARIFBytes(wrapped)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error: failed to build SARIF report: %v\n", err)
+				os.Exit(ExitNetworkError)
+			}
+			fmt.Println(string(sarifBytes))
+			return
 		}
 
 		fmt.Println("## Nullify Security Report")
@@ -268,6 +301,7 @@ func init() {
 	ciGateCmd.Flags().String("repo", "", "Repository name (auto-detected from git if not set)")
 
 	ciReportCmd.Flags().String("repo", "", "Repository name (auto-detected from git if not set)")
+	ciReportCmd.Flags().String("format", "markdown", "Report format (markdown, sarif)")
 }
 
 func severitiesAboveThreshold(threshold string) []string {
@@ -301,4 +335,57 @@ func countFindings(body string) int {
 	}
 
 	return 0
+}
+
+// totalFindingsCount extracts an accurate finding count from an API response.
+// It prefers the response's "total" field (which reflects the full result set
+// regardless of the request's limit) over the length of the truncated items
+// array. Falls back to array/items length when no total is present.
+func totalFindingsCount(body string) int {
+	var result any
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return 0
+	}
+
+	switch v := result.(type) {
+	case []any:
+		return len(v)
+	case map[string]any:
+		if total, ok := v["total"].(float64); ok {
+			return int(total)
+		}
+		if items, ok := v["items"].([]any); ok {
+			return len(items)
+		}
+		if findings, ok := v["findings"].([]any); ok {
+			return len(findings)
+		}
+	}
+
+	return 0
+}
+
+// extractFindings pulls the finding objects out of an API response body so they
+// can be rendered (e.g. as SARIF). It understands a top-level array as well as
+// the common {findings:[...]} and {items:[...]} envelopes.
+func extractFindings(body string) []json.RawMessage {
+	var arr []json.RawMessage
+	if err := json.Unmarshal([]byte(body), &arr); err == nil {
+		return arr
+	}
+
+	var obj struct {
+		Findings []json.RawMessage `json:"findings"`
+		Items    []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal([]byte(body), &obj); err == nil {
+		if obj.Findings != nil {
+			return obj.Findings
+		}
+		if obj.Items != nil {
+			return obj.Items
+		}
+	}
+
+	return nil
 }

--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -54,7 +54,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&host, "host", "", "The base URL of your Nullify API instance (e.g., acme.nullify.ai)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose logging")
 	rootCmd.PersistentFlags().BoolVarP(&debug, "debug", "d", false, "Enable debug logging")
-	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "Output format (json, table, yaml)")
+	rootCmd.PersistentFlags().StringVarP(&outputFmt, "output", "o", "json", "Output format (json, table, yaml, sarif)")
 	rootCmd.PersistentFlags().StringVar(&nullifyToken, "nullify-token", "", "Nullify API token")
 	rootCmd.PersistentFlags().StringVar(&githubToken, "github-token", "", "GitHub actions job token to exchange for a Nullify API token")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "Suppress informational output")

--- a/internal/output/sarif.go
+++ b/internal/output/sarif.go
@@ -24,18 +24,41 @@ type sarifTool struct {
 }
 
 type sarifDriver struct {
-	Name    string `json:"name"`
-	Version string `json:"version,omitempty"`
+	Name    string      `json:"name"`
+	Version string      `json:"version,omitempty"`
+	Rules   []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID string `json:"id"`
 }
 
 type sarifResult struct {
-	RuleID  string       `json:"ruleId,omitempty"`
-	Level   string       `json:"level"`
-	Message sarifMessage `json:"message"`
+	RuleID    string          `json:"ruleId,omitempty"`
+	Level     string          `json:"level"`
+	Message   sarifMessage    `json:"message"`
+	Locations []sarifLocation `json:"locations,omitempty"`
 }
 
 type sarifMessage struct {
 	Text string `json:"text"`
+}
+
+type sarifLocation struct {
+	PhysicalLocation sarifPhysicalLocation `json:"physicalLocation"`
+}
+
+type sarifPhysicalLocation struct {
+	ArtifactLocation sarifArtifactLocation `json:"artifactLocation"`
+	Region           *sarifRegion          `json:"region,omitempty"`
+}
+
+type sarifArtifactLocation struct {
+	URI string `json:"uri"`
+}
+
+type sarifRegion struct {
+	StartLine int `json:"startLine"`
 }
 
 func severityToSARIFLevel(severity string) string {
@@ -51,81 +74,213 @@ func severityToSARIFLevel(severity string) string {
 	}
 }
 
-func printSARIF(data []byte) error {
-	// Try to parse as an array of finding-like objects
-	var findings []map[string]any
-	if err := json.Unmarshal(data, &findings); err != nil {
-		// Try as wrapped type results
-		var typeResults []struct {
-			Type  string          `json:"type"`
-			Error string          `json:"error,omitempty"`
-			Data  json.RawMessage `json:"data,omitempty"`
+// firstString returns the first non-empty string value found among the given keys.
+func firstString(f map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if s, ok := f[k].(string); ok && s != "" {
+			return s
 		}
-		if err2 := json.Unmarshal(data, &typeResults); err2 != nil {
-			return fmt.Errorf("cannot convert data to SARIF format: %w", err)
-		}
+	}
+	return ""
+}
 
-		// Flatten type results into findings
-		for _, tr := range typeResults {
-			if tr.Error != "" || len(tr.Data) == 0 {
-				continue
+// firstInt returns the first integer-like value found among the given keys.
+// JSON numbers decode to float64; numeric strings are also accepted.
+func firstInt(f map[string]any, keys ...string) (int, bool) {
+	for _, k := range keys {
+		switch v := f[k].(type) {
+		case float64:
+			return int(v), true
+		case int:
+			return v, true
+		case json.Number:
+			if n, err := v.Int64(); err == nil {
+				return int(n), true
 			}
-			var items []map[string]any
-			if err := json.Unmarshal(tr.Data, &items); err != nil {
-				// Try as {items: [...]}
-				var wrapped struct {
-					Items []map[string]any `json:"items"`
-				}
-				if err2 := json.Unmarshal(tr.Data, &wrapped); err2 == nil {
-					items = wrapped.Items
-				}
+		}
+	}
+	return 0, false
+}
+
+// buildLocation extracts a SARIF location from common location field shapes.
+// Returns nil if no usable location data is present.
+func buildLocation(f map[string]any) *sarifLocation {
+	uri := firstString(f, "filePath", "file", "path", "uri", "url", "location")
+	if uri == "" {
+		return nil
+	}
+
+	loc := &sarifLocation{
+		PhysicalLocation: sarifPhysicalLocation{
+			ArtifactLocation: sarifArtifactLocation{URI: uri},
+		},
+	}
+
+	if line, ok := firstInt(f, "startLine", "line", "lineNumber"); ok && line > 0 {
+		loc.PhysicalLocation.Region = &sarifRegion{StartLine: line}
+	}
+
+	return loc
+}
+
+// unwrapFindings normalises the various JSON envelopes the CLI emits into a
+// flat slice of finding-like objects:
+//   - a top-level array: [ {...}, {...} ]
+//   - the findings command object: { "findings": [...], "total": N }
+//   - wrapped per-type results: [ { "type": ..., "data": [...] }, ... ]
+func unwrapFindings(data []byte) []map[string]any {
+	// 1. { "findings": [...], "total": N }
+	var obj struct {
+		Findings []map[string]any `json:"findings"`
+	}
+	if err := json.Unmarshal(data, &obj); err == nil && obj.Findings != nil {
+		return obj.Findings
+	}
+
+	// 2. Top-level array. This may be a plain array of findings or an array of
+	// wrapped per-type results ([{type, data:[...]}, ...]). Detect the wrapper
+	// shape and unwrap it; otherwise treat the array as findings directly.
+	var arr []map[string]any
+	if err := json.Unmarshal(data, &arr); err == nil {
+		if wrapped := unwrapTypeResults(data); wrapped != nil {
+			return wrapped
+		}
+		return arr
+	}
+
+	// 3. Wrapped per-type results that aren't a plain array of objects.
+	if wrapped := unwrapTypeResults(data); wrapped != nil {
+		return wrapped
+	}
+
+	return nil
+}
+
+// unwrapTypeResults flattens the wrapped per-type results envelope
+// ([{type, error, data:[...]}, ...]) into a flat findings slice. It returns nil
+// when the data is not that shape (e.g. it's a plain findings array).
+func unwrapTypeResults(data []byte) []map[string]any {
+	var typeResults []struct {
+		Type  string          `json:"type"`
+		Error string          `json:"error,omitempty"`
+		Data  json.RawMessage `json:"data,omitempty"`
+	}
+	if err := json.Unmarshal(data, &typeResults); err != nil {
+		return nil
+	}
+
+	// Only treat this as the wrapper shape if at least one element actually
+	// carries a typed data payload; otherwise it's a plain findings array.
+	hasWrapper := false
+	for _, tr := range typeResults {
+		if tr.Type != "" || len(tr.Data) > 0 {
+			hasWrapper = true
+			break
+		}
+	}
+	if !hasWrapper {
+		return nil
+	}
+
+	var out []map[string]any
+	for _, tr := range typeResults {
+		if tr.Error != "" || len(tr.Data) == 0 {
+			continue
+		}
+		var items []map[string]any
+		if err := json.Unmarshal(tr.Data, &items); err != nil {
+			var wrapped struct {
+				Items []map[string]any `json:"items"`
 			}
-			for i := range items {
+			if err2 := json.Unmarshal(tr.Data, &wrapped); err2 == nil {
+				items = wrapped.Items
+			}
+		}
+		for i := range items {
+			if items[i] != nil {
 				items[i]["_type"] = tr.Type
 			}
-			findings = append(findings, items...)
 		}
+		out = append(out, items...)
+	}
+	return out
+}
+
+// buildSARIF converts CLI finding JSON into a SARIF v2.1.0 document.
+func buildSARIF(data []byte) (sarifLog, error) {
+	findings := unwrapFindings(data)
+	if findings == nil {
+		return sarifLog{}, fmt.Errorf("cannot convert data to SARIF format: unrecognized JSON shape")
 	}
 
 	var results []sarifResult
+	ruleSeen := map[string]bool{}
+	var rules []sarifRule
+
 	for _, f := range findings {
-		severity, _ := f["severity"].(string)
-		title, _ := f["title"].(string)
-		description, _ := f["description"].(string)
-		ruleID, _ := f["rule_id"].(string)
-		if ruleID == "" {
-			ruleID, _ = f["id"].(string)
+		if f == nil {
+			continue
 		}
+
+		severity := firstString(f, "severity")
+		title := firstString(f, "title")
+		description := firstString(f, "description")
+		ruleID := firstString(f, "rule_id", "ruleId", "id")
 
 		msg := title
 		if description != "" && msg != description {
-			msg = title + ": " + description
+			if msg != "" {
+				msg = title + ": " + description
+			} else {
+				msg = description
+			}
 		}
 		if msg == "" {
 			msg = "Security finding"
 		}
 
-		results = append(results, sarifResult{
+		result := sarifResult{
 			RuleID:  ruleID,
 			Level:   severityToSARIFLevel(severity),
 			Message: sarifMessage{Text: msg},
-		})
+		}
+		if loc := buildLocation(f); loc != nil {
+			result.Locations = []sarifLocation{*loc}
+		}
+		results = append(results, result)
+
+		if ruleID != "" && !ruleSeen[ruleID] {
+			ruleSeen[ruleID] = true
+			rules = append(rules, sarifRule{ID: ruleID})
+		}
 	}
 
-	log := sarifLog{
+	return sarifLog{
 		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
 		Version: "2.1.0",
 		Runs: []sarifRun{
 			{
 				Tool: sarifTool{
-					Driver: sarifDriver{Name: "Nullify"},
+					Driver: sarifDriver{Name: "Nullify", Rules: rules},
 				},
 				Results: results,
 			},
 		},
-	}
+	}, nil
+}
 
-	out, err := json.MarshalIndent(log, "", "  ")
+// SARIFBytes converts CLI finding JSON into an indented SARIF document.
+// Exported so other commands (e.g. `ci report --format sarif`) can reuse it.
+func SARIFBytes(data []byte) ([]byte, error) {
+	log, err := buildSARIF(data)
+	if err != nil {
+		return nil, err
+	}
+	return json.MarshalIndent(log, "", "  ")
+}
+
+func printSARIF(data []byte) error {
+	out, err := SARIFBytes(data)
 	if err != nil {
 		return err
 	}

--- a/internal/output/sarif_test.go
+++ b/internal/output/sarif_test.go
@@ -1,0 +1,207 @@
+package output
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestSeverityToSARIFLevel(t *testing.T) {
+	tests := []struct {
+		severity string
+		want     string
+	}{
+		{"critical", "error"},
+		{"CRITICAL", "error"},
+		{"high", "error"},
+		{"medium", "warning"},
+		{"low", "note"},
+		{"info", "note"},
+		{"informational", "note"},
+		{"", "warning"},
+		{"weird", "warning"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.severity, func(t *testing.T) {
+			if got := severityToSARIFLevel(tt.severity); got != tt.want {
+				t.Errorf("severityToSARIFLevel(%q) = %q, want %q", tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildSARIF(t *testing.T) {
+	tests := []struct {
+		name        string
+		data        string
+		wantErr     bool
+		wantResults int
+		wantRules   []string
+		// assert checks the produced log for shape-specific expectations.
+		assert func(t *testing.T, log sarifLog)
+	}{
+		{
+			name:    "unrecognized shape errors",
+			data:    `"just a string"`,
+			wantErr: true,
+		},
+		{
+			name:        "empty findings object",
+			data:        `{"findings": [], "total": 0}`,
+			wantResults: 0,
+		},
+		{
+			name:        "empty top-level array",
+			data:        `[]`,
+			wantResults: 0,
+		},
+		{
+			name: "findings object with locations and rules",
+			data: `{"findings":[
+				{"severity":"critical","title":"SQLi","ruleId":"sql-injection","filePath":"src/db.go","startLine":42},
+				{"severity":"high","title":"XSS","ruleId":"xss","file":"web.js","line":7}
+			],"total":2}`,
+			wantResults: 2,
+			wantRules:   []string{"sql-injection", "xss"},
+			assert: func(t *testing.T, log sarifLog) {
+				res := log.Runs[0].Results
+				if res[0].Level != "error" {
+					t.Errorf("result[0] level = %q, want error", res[0].Level)
+				}
+				if len(res[0].Locations) != 1 {
+					t.Fatalf("result[0] expected 1 location, got %d", len(res[0].Locations))
+				}
+				loc := res[0].Locations[0].PhysicalLocation
+				if loc.ArtifactLocation.URI != "src/db.go" {
+					t.Errorf("uri = %q, want src/db.go", loc.ArtifactLocation.URI)
+				}
+				if loc.Region == nil || loc.Region.StartLine != 42 {
+					t.Errorf("region = %+v, want startLine 42", loc.Region)
+				}
+			},
+		},
+		{
+			name:        "top-level array shape still works",
+			data:        `[{"severity":"medium","title":"Weak crypto","id":"crypto-1"}]`,
+			wantResults: 1,
+			wantRules:   []string{"crypto-1"},
+			assert: func(t *testing.T, log sarifLog) {
+				if log.Runs[0].Results[0].Level != "warning" {
+					t.Errorf("level = %q, want warning", log.Runs[0].Results[0].Level)
+				}
+			},
+		},
+		{
+			name:        "dast finding uses url for location",
+			data:        `{"findings":[{"severity":"high","title":"Open redirect","rule_id":"redirect","url":"https://x.test/a"}],"total":1}`,
+			wantResults: 1,
+			wantRules:   []string{"redirect"},
+			assert: func(t *testing.T, log sarifLog) {
+				loc := log.Runs[0].Results[0].Locations
+				if len(loc) != 1 {
+					t.Fatalf("expected 1 location, got %d", len(loc))
+				}
+				if loc[0].PhysicalLocation.ArtifactLocation.URI != "https://x.test/a" {
+					t.Errorf("uri = %q, want url", loc[0].PhysicalLocation.ArtifactLocation.URI)
+				}
+				if loc[0].PhysicalLocation.Region != nil {
+					t.Errorf("expected no region for url-only finding, got %+v", loc[0].PhysicalLocation.Region)
+				}
+			},
+		},
+		{
+			name:        "missing fields do not panic and omit location",
+			data:        `{"findings":[{}],"total":1}`,
+			wantResults: 1,
+			wantRules:   nil,
+			assert: func(t *testing.T, log sarifLog) {
+				r := log.Runs[0].Results[0]
+				if r.Message.Text != "Security finding" {
+					t.Errorf("message = %q, want default", r.Message.Text)
+				}
+				if len(r.Locations) != 0 {
+					t.Errorf("expected no locations, got %d", len(r.Locations))
+				}
+			},
+		},
+		{
+			name:        "duplicate ruleIds deduped in rules",
+			data:        `{"findings":[{"ruleId":"r1","title":"a"},{"ruleId":"r1","title":"b"}],"total":2}`,
+			wantResults: 2,
+			wantRules:   []string{"r1"},
+		},
+		{
+			name:        "wrapped per-type results",
+			data:        `[{"type":"sast","data":[{"severity":"low","title":"Lint","ruleId":"lint-1","path":"a.go","lineNumber":3}]}]`,
+			wantResults: 1,
+			wantRules:   []string{"lint-1"},
+			assert: func(t *testing.T, log sarifLog) {
+				loc := log.Runs[0].Results[0].Locations
+				if len(loc) != 1 || loc[0].PhysicalLocation.Region == nil || loc[0].PhysicalLocation.Region.StartLine != 3 {
+					t.Errorf("expected location with startLine 3, got %+v", loc)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log, err := buildSARIF([]byte(tt.data))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if log.Version != "2.1.0" {
+				t.Errorf("version = %q, want 2.1.0", log.Version)
+			}
+			if len(log.Runs) != 1 {
+				t.Fatalf("expected 1 run, got %d", len(log.Runs))
+			}
+
+			run := log.Runs[0]
+			if len(run.Results) != tt.wantResults {
+				t.Errorf("results = %d, want %d", len(run.Results), tt.wantResults)
+			}
+
+			gotRules := make([]string, 0, len(run.Tool.Driver.Rules))
+			for _, r := range run.Tool.Driver.Rules {
+				gotRules = append(gotRules, r.ID)
+			}
+			if len(gotRules) != len(tt.wantRules) {
+				t.Fatalf("rules = %v, want %v", gotRules, tt.wantRules)
+			}
+			for i, id := range tt.wantRules {
+				if gotRules[i] != id {
+					t.Errorf("rules[%d] = %q, want %q", i, gotRules[i], id)
+				}
+			}
+
+			if tt.assert != nil {
+				tt.assert(t, log)
+			}
+		})
+	}
+}
+
+func TestSARIFBytesValidJSON(t *testing.T) {
+	data := `{"findings":[{"severity":"high","title":"x","ruleId":"r","filePath":"f.go","startLine":1}],"total":1}`
+	out, err := SARIFBytes([]byte(data))
+	if err != nil {
+		t.Fatalf("SARIFBytes error: %v", err)
+	}
+	if len(out) == 0 {
+		t.Fatal("expected non-empty SARIF output")
+	}
+	var doc sarifLog
+	if err := json.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("SARIFBytes produced invalid JSON: %v", err)
+	}
+	if doc.Version != "2.1.0" || len(doc.Runs) != 1 {
+		t.Errorf("unexpected SARIF doc: %+v", doc)
+	}
+}


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Why

The SARIF formatter (`internal/output/sarif.go`) only accepted a top-level JSON array or a `{type,data}` wrapper, so `nullify findings -o sarif` failed — the `findings` command emits `{"findings":[...],"total":N}`. The output also emitted only `ruleId`/`level`/`message`, with no `locations[]` (consumers couldn't place findings) and no `rules[]` driver section (so `ruleId` references dangled).

The `ci` command also didn't expose SARIF at all, `ci gate` reported truncated counts (it queried with `limit=1` then counted the items array), and it only failed when *all* scanner requests errored — silently passing if some scanners failed.

## What

**`internal/output/sarif.go`**
- Unwrap the `{findings,total}` object shape, in addition to the existing top-level array and `{type,data}` wrapper.
- Emit a `locations[]` entry per finding from common location keys: `filePath`/`file`/`path` + `startLine`/`line`/`lineNumber` for code, and `uri`/`url` for DAST.
- Emit a distinct `rules[]` array under `tool.driver.rules` from the rule IDs seen, so references resolve.
- Severity → level mapping preserved (critical/high → `error`, medium → `warning`, low/info → `note`, unknown → `warning`). Defensive against missing fields (no panics).
- Exposed `SARIFBytes()` for reuse by `ci report`.

**`cmd/cli/cmd/root.go`**
- `--output`/`-o` usage string now lists `sarif`.

**`cmd/cli/cmd/ci.go`**
- `ci report` gains a `--format` flag: `markdown` (default) or `sarif`.
- `ci gate` counts via the response `total` field instead of the limit-truncated items array, for accurate counts.
- `ci gate` is now fail-closed: any scanner request error fails the gate (non-zero exit) instead of only failing when every request errors.

**Tests**
- Table-driven SARIF tests covering the `{findings,total}` object, locations, rules, dedup, DAST url locations, wrapped per-type results, and missing-field defensiveness. Existing tests still pass.

## Verification
- `GOWORK=off CGO_ENABLED=0 go build ./...`
- `GOWORK=off go vet ./...`
- `GOWORK=off go test ./...`
- `golangci-lint run` (0 issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)