### PR TITLE
feat(api): default retry transport, structured errors, configurable timeout

### DIFF
--- a/cmd/cli/cmd/root.go
+++ b/cmd/cli/cmd/root.go
@@ -2,9 +2,7 @@ package cmd
 
 import (
 	"context"
-	"net/http"
 	"os"
-	"time"
 
 	"github.com/nullify-platform/cli/internal/api"
 	"github.com/nullify-platform/cli/internal/auth"
@@ -84,11 +82,9 @@ func init() {
 			}
 		}
 
-		retryHTTPClient := &http.Client{
-			Timeout:   30 * time.Second,
-			Transport: client.NewRetryTransport(http.DefaultTransport),
-		}
-		return api.NewClient(nullifyHost, token, defaultParams, api.WithHTTPClient(retryHTTPClient))
+		// api.NewClient defaults to a retrying HTTP client, so no
+		// WithHTTPClient override is needed here.
+		return api.NewClient(nullifyHost, token, defaultParams)
 	}
 
 	// Register generated API commands under 'api' parent for cleaner top-level help

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -3,15 +3,34 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/nullify-platform/cli/internal/apierror"
+	"github.com/nullify-platform/cli/internal/client"
 )
 
 // Version is set at build time via ldflags.
 var Version = "dev"
+
+// defaultTimeout is the request timeout used when NULLIFY_HTTP_TIMEOUT is unset
+// or invalid. 30s is too short for long-running calls (scan-start, autofix), so
+// callers can raise it via the env var (e.g. "120s").
+const defaultTimeout = 30 * time.Second
+
+// httpTimeout returns the request timeout, overridable via the
+// NULLIFY_HTTP_TIMEOUT env var (a Go duration string such as "120s").
+func httpTimeout() time.Duration {
+	if v := os.Getenv("NULLIFY_HTTP_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultTimeout
+}
 
 // Client is a typed HTTP client for the Nullify API.
 type Client struct {
@@ -24,12 +43,14 @@ type Client struct {
 // ClientOption configures a Client.
 type ClientOption func(*Client)
 
-// WithHTTPClient sets a custom HTTP client on the API client.
+// WithHTTPClient sets a custom HTTP client on the API client, overriding the
+// default retrying client.
 func WithHTTPClient(hc *http.Client) ClientOption {
 	return func(c *Client) { c.HTTPClient = hc }
 }
 
-// NewClient creates a new Nullify API client.
+// NewClient creates a new Nullify API client. By default it retries on 429 and
+// 5xx responses (callers get retries without passing WithHTTPClient).
 func NewClient(host string, token string, defaultParams map[string]string, opts ...ClientOption) *Client {
 	apiHost := host
 	if !strings.HasPrefix(host, "api.") {
@@ -39,7 +60,10 @@ func NewClient(host string, token string, defaultParams map[string]string, opts 
 		BaseURL:       "https://" + apiHost,
 		Token:         token,
 		DefaultParams: defaultParams,
-		HTTPClient:    &http.Client{Timeout: 30 * time.Second},
+		HTTPClient: &http.Client{
+			Timeout:   httpTimeout(),
+			Transport: client.NewRetryTransport(http.DefaultTransport),
+		},
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -65,13 +89,13 @@ func (c *Client) do(ctx context.Context, method, url string, body io.Reader) ([]
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, apierror.HandleError(resp)
+	}
+
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	return respBody, nil

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -2,9 +2,13 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
+
+	"github.com/nullify-platform/cli/internal/apierror"
 )
 
 func TestClientDo_Success(t *testing.T) {
@@ -34,6 +38,7 @@ func TestClientDo_Success(t *testing.T) {
 
 func TestClientDo_4xxError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
 		_, _ = w.Write([]byte(`{"error":"not found"}`))
 	}))
@@ -49,10 +54,25 @@ func TestClientDo_4xxError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for 404")
 	}
+
+	var apiErr *apierror.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *apierror.APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusNotFound {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusNotFound)
+	}
+	if !apiErr.IsNotFound() {
+		t.Error("expected IsNotFound() to be true")
+	}
+	if apiErr.Message != "not found" {
+		t.Errorf("Message = %q, want %q", apiErr.Message, "not found")
+	}
 }
 
 func TestClientDo_5xxError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte(`{"error":"internal error"}`))
 	}))
@@ -67,5 +87,67 @@ func TestClientDo_5xxError(t *testing.T) {
 	_, err := client.do(context.Background(), "GET", server.URL+"/error", nil)
 	if err == nil {
 		t.Fatal("expected error for 500")
+	}
+
+	var apiErr *apierror.APIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("expected *apierror.APIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != http.StatusInternalServerError {
+		t.Errorf("StatusCode = %d, want %d", apiErr.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestHTTPTimeout(t *testing.T) {
+	t.Run("default when unset", func(t *testing.T) {
+		t.Setenv("NULLIFY_HTTP_TIMEOUT", "")
+		if got := httpTimeout(); got != defaultTimeout {
+			t.Errorf("httpTimeout() = %v, want %v", got, defaultTimeout)
+		}
+	})
+
+	t.Run("overrides from env", func(t *testing.T) {
+		t.Setenv("NULLIFY_HTTP_TIMEOUT", "120s")
+		if got := httpTimeout(); got != 120*time.Second {
+			t.Errorf("httpTimeout() = %v, want %v", got, 120*time.Second)
+		}
+	})
+
+	t.Run("falls back to default on invalid", func(t *testing.T) {
+		t.Setenv("NULLIFY_HTTP_TIMEOUT", "not-a-duration")
+		if got := httpTimeout(); got != defaultTimeout {
+			t.Errorf("httpTimeout() = %v, want %v", got, defaultTimeout)
+		}
+	})
+
+	t.Run("falls back to default on non-positive", func(t *testing.T) {
+		t.Setenv("NULLIFY_HTTP_TIMEOUT", "0s")
+		if got := httpTimeout(); got != defaultTimeout {
+			t.Errorf("httpTimeout() = %v, want %v", got, defaultTimeout)
+		}
+	})
+}
+
+func TestNewClient_DefaultsToRetryingClient(t *testing.T) {
+	c := NewClient("example.com", "tok", nil)
+	if c.HTTPClient == nil {
+		t.Fatal("expected default HTTPClient to be non-nil")
+	}
+	if c.HTTPClient.Transport == nil {
+		t.Fatal("expected default HTTPClient.Transport to be non-nil (retry transport)")
+	}
+	if c.HTTPClient.Timeout != defaultTimeout {
+		t.Errorf("Timeout = %v, want %v", c.HTTPClient.Timeout, defaultTimeout)
+	}
+	if c.BaseURL != "https://api.example.com" {
+		t.Errorf("BaseURL = %q, want %q", c.BaseURL, "https://api.example.com")
+	}
+}
+
+func TestNewClient_WithHTTPClientOverride(t *testing.T) {
+	custom := &http.Client{}
+	c := NewClient("example.com", "tok", nil, WithHTTPClient(custom))
+	if c.HTTPClient != custom {
+		t.Error("expected WithHTTPClient to override the default client")
 	}
 }

--- a/scripts/generate/main.go
+++ b/scripts/generate/main.go
@@ -478,15 +478,34 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
+
+	"github.com/nullify-platform/cli/internal/apierror"
+	"github.com/nullify-platform/cli/internal/client"
 )
 
 // Version is set at build time via ldflags.
 var Version = "dev"
+
+// defaultTimeout is the request timeout used when NULLIFY_HTTP_TIMEOUT is unset
+// or invalid. 30s is too short for long-running calls (scan-start, autofix), so
+// callers can raise it via the env var (e.g. "120s").
+const defaultTimeout = 30 * time.Second
+
+// httpTimeout returns the request timeout, overridable via the
+// NULLIFY_HTTP_TIMEOUT env var (a Go duration string such as "120s").
+func httpTimeout() time.Duration {
+	if v := os.Getenv("NULLIFY_HTTP_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultTimeout
+}
 
 // Client is a typed HTTP client for the Nullify API.
 type Client struct {
@@ -499,12 +518,14 @@ type Client struct {
 // ClientOption configures a Client.
 type ClientOption func(*Client)
 
-// WithHTTPClient sets a custom HTTP client on the API client.
+// WithHTTPClient sets a custom HTTP client on the API client, overriding the
+// default retrying client.
 func WithHTTPClient(hc *http.Client) ClientOption {
 	return func(c *Client) { c.HTTPClient = hc }
 }
 
-// NewClient creates a new Nullify API client.
+// NewClient creates a new Nullify API client. By default it retries on 429 and
+// 5xx responses (callers get retries without passing WithHTTPClient).
 func NewClient(host string, token string, defaultParams map[string]string, opts ...ClientOption) *Client {
 	apiHost := host
 	if !strings.HasPrefix(host, "api.") {
@@ -514,7 +535,10 @@ func NewClient(host string, token string, defaultParams map[string]string, opts 
 		BaseURL:       "https://" + apiHost,
 		Token:         token,
 		DefaultParams: defaultParams,
-		HTTPClient:    &http.Client{Timeout: 30 * time.Second},
+		HTTPClient: &http.Client{
+			Timeout:   httpTimeout(),
+			Transport: client.NewRetryTransport(http.DefaultTransport),
+		},
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -540,13 +564,13 @@ func (c *Client) do(ctx context.Context, method, url string, body io.Reader) ([]
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, apierror.HandleError(resp)
+	}
+
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 10<<20))
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, fmt.Errorf("API returned %d: %s", resp.StatusCode, string(respBody))
 	}
 
 	return respBody, nil


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Summary

The generated typed API client (`internal/api`) had no retry by default, returned only stringified errors, and used a hardcoded 30s timeout (too short for scan-start / autofix). This PR makes retry the default, returns structured errors, and makes the timeout configurable.

`internal/api/client.go` is **generated** by `writeBaseClient` in `scripts/generate/main.go`, so the template there is the real change; `client.go` was regenerated via `make generate-api` (offline, reads vendored `spec/`).

## Changes

- **Default retry** — `NewClient` now defaults its `HTTPClient.Transport` to `client.NewRetryTransport(http.DefaultTransport)`, so every caller gets 429/5xx retries without passing `WithHTTPClient`. The `WithHTTPClient` override still works.
- **Structured errors** — on non-2xx, `do()` now returns `*apierror.APIError` (via `apierror.HandleError`) carrying `StatusCode` + parsed message instead of a bare `fmt.Errorf`. No import cycle: `internal/apierror` and `internal/client` do not import `internal/api`.
- **Configurable timeout** — the hardcoded 30s is now overridable via `NULLIFY_HTTP_TIMEOUT` (a Go duration string such as `"120s"`); defaults to 30s, falls back to default on empty/invalid/non-positive values.
- **root.go** — removed the now-redundant `WithHTTPClient` retry-client injection (kept building).

## Tests

- `TestHTTPTimeout` — env parsing (default / override / invalid / non-positive).
- `TestNewClient_DefaultsToRetryingClient` — default client has a non-nil retry transport and 30s timeout.
- `TestNewClient_WithHTTPClientOverride` — override still wins.
- Updated `TestClientDo_4xxError` / `TestClientDo_5xxError` to assert the returned error is an `*apierror.APIError` with the correct `StatusCode` (and parsed message / `IsNotFound()`).

Verified from worktree root: `GOWORK=off CGO_ENABLED=0 go build ./...`, `GOWORK=off go vet ./...`, `GOWORK=off go test ./...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)