### PR TITLE
fix(cli): send GitHub PAT in POST body, not the URL query string

### DIFF
--- a/internal/lib/get_token.go
+++ b/internal/lib/get_token.go
@@ -1,12 +1,12 @@
 package lib
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -60,13 +60,19 @@ func GetNullifyToken(
 
 		owner := parts[0]
 
-		// TODO(security): Migrate to POST with JSON body on the backend (security-droid) to avoid sending GitHub token in query string.
-		tokenURL := fmt.Sprintf("https://%s/auth/github_token?token=%s&owner=%s", nullifyHost, url.QueryEscape(githubTokenFlag), url.QueryEscape(owner))
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, tokenURL, nil)
+		// Send the PAT in a POST body, never the URL, so it can't leak into
+		// access logs or proxies. (The backend retains GET for older CLIs.)
+		reqBody, err := json.Marshal(map[string]string{"owner": owner, "token": githubTokenFlag})
 		if err != nil {
 			return "", err
 		}
+		tokenURL := fmt.Sprintf("https://%s/auth/github_token", nullifyHost)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenURL, bytes.NewReader(reqBody))
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("Content-Type", "application/json")
 
 		httpClient := &http.Client{Timeout: 30 * time.Second}
 		res, err := httpClient.Do(req)


### PR DESCRIPTION
![Claude](https://img.shields.io/badge/Claude-Anthropic-blueviolet?logo=anthropic)

## Why
The GitHub-Actions token exchange (`internal/lib/get_token.go`) sent the GitHub PAT in the **URL query string** (`/auth/github_token?token=…`), where it leaks into access logs, proxies, and request-logging middleware. The code carried a standing `TODO(security)`.

## What
Send `{owner, token}` as a JSON **POST body** to `/auth/github_token` with `Content-Type: application/json`. No other behavior changes.

## Rollout ordering ⚠️
This is the **client half** of a coordinated change. The backend POST support is **nullify monorepo PR #5485** (`feat(auth): accept GitHub token via POST body`). That must merge **and deploy** before this CLI change ships, otherwise the CLI would POST to a GET-only endpoint. Both are drafts until then; the backend keeps GET for already-released CLIs.

## Test plan
- `go build ./...`, `go vet ./internal/lib/...`, `go test ./internal/lib/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)